### PR TITLE
Add dependency on typing_extensions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "aiohttp>=3.1", # 3.1 adds AsyncIterablePayload, which we need
     "multidict",
     "protobuf",
+    "typing-extensions>=4.14.0",
     "urllib3>=2.5.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
     "python_full_version >= '3.11'",
@@ -384,6 +384,7 @@ dependencies = [
     { name = "aiohttp" },
     { name = "multidict" },
     { name = "protobuf" },
+    { name = "typing-extensions" },
     { name = "urllib3" },
 ]
 
@@ -441,6 +442,7 @@ requires-dist = [
     { name = "sphinx", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "sphinx-autodoc-typehints", marker = "extra == 'dev'", specifier = ">=1.25.0" },
     { name = "sphinx-rtd-theme", marker = "extra == 'dev'", specifier = ">=2.0.0" },
+    { name = "typing-extensions", specifier = ">=4.14.0" },
     { name = "urllib3", specifier = ">=2.5.0" },
 ]
 provides-extras = ["compiler", "dev"]


### PR DESCRIPTION
We use it [here][1], but don't have it declared in our dependencies.

Noticed this while trying out the [BSR plugin][2].

[1]: https://github.com/connectrpc/connect-python/blob/34e009e25b16637a1945ec42c4e6069dde8cd466/src/connectrpc/streams.py#L12
[2]: https://github.com/bufbuild/plugins/pull/1933