### PR TITLE
Attempt fix for uv Dependabot

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ Issues = "https://github.com/connectrpc/connect-python/issues"
 
 [tool.hatch.version]
 source = "vcs"
-raw-options = { local_scheme = "no-local-version" }
+raw-options = { local_scheme = "no-local-version", fallback_version = "0.0.0" }
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/connectrpc"]


### PR DESCRIPTION
(Sorry for the barrage of PRs, calling it for the day after this one.)

Dependabot failed to run for uv:

https://github.com/connectrpc/connect-python/actions/runs/16681250850/job/47220205967

Found a fix, here:

https://github.com/dependabot/dependabot-core/issues/12340#issuecomment-3000630760

Makes me nervous that a stray release could end up with a 0.0.0 version, but we could just yank it - hopefully the upstream bug is fixed soon.

Ref: https://setuptools-scm.readthedocs.io/en/latest/config/#configuration-parameters