### PR TITLE
Remove conformance submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "tests/conformance/vendor/conformance"]
-	path = tests/conformance/vendor/conformance
-	url = https://github.com/connectrpc/conformance.git

--- a/examples/eliza_pb2_connect.py
+++ b/examples/eliza_pb2_connect.py
@@ -44,7 +44,7 @@ class ElizaServiceClient:
         self.base_url = base_url
         self._connect_client = ConnectClient(http_client, protocol)
     def call_say(
-        self, req: eliza_pb2.SayRequest,extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None
+        self, req: eliza_pb2.SayRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None
     ) -> UnaryOutput[eliza_pb2.SayResponse]:
         """Low-level method to call Say, granting access to errors and metadata"""
         url = self.base_url + "/connectrpc.eliza.v1.ElizaService/Say"

--- a/tests/conformance/buf.gen.yaml
+++ b/tests/conformance/buf.gen.yaml
@@ -6,3 +6,5 @@ plugins:
     out: .
   - local: ../../.venv/bin/protoc-gen-connect_python
     out: .
+inputs:
+  - module: buf.build/connectrpc/conformance:v1.0.4

--- a/tests/conformance/buf.yaml
+++ b/tests/conformance/buf.yaml
@@ -1,4 +1,0 @@
-version: v2
-modules:
-  - path: vendor/conformance/proto
-    name: buf.build/connectrpc/conformance

--- a/tests/conformance/connectrpc/conformance/v1/service_pb2_connect.py
+++ b/tests/conformance/connectrpc/conformance/v1/service_pb2_connect.py
@@ -44,7 +44,7 @@ class ConformanceServiceClient:
         self.base_url = base_url
         self._connect_client = ConnectClient(http_client, protocol)
     def call_unary(
-        self, req: connectrpc.conformance.v1.service_pb2.UnaryRequest,extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None
+        self, req: connectrpc.conformance.v1.service_pb2.UnaryRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None
     ) -> UnaryOutput[connectrpc.conformance.v1.service_pb2.UnaryResponse]:
         """Low-level method to call Unary, granting access to errors and metadata"""
         url = self.base_url + "/connectrpc.conformance.v1.ConformanceService/Unary"
@@ -137,7 +137,7 @@ class ConformanceServiceClient:
         )
 
     def call_unimplemented(
-        self, req: connectrpc.conformance.v1.service_pb2.UnimplementedRequest,extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None
+        self, req: connectrpc.conformance.v1.service_pb2.UnimplementedRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None
     ) -> UnaryOutput[connectrpc.conformance.v1.service_pb2.UnimplementedResponse]:
         """Low-level method to call Unimplemented, granting access to errors and metadata"""
         url = self.base_url + "/connectrpc.conformance.v1.ConformanceService/Unimplemented"
@@ -157,7 +157,7 @@ class ConformanceServiceClient:
         return msg
 
     def call_idempotent_unary(
-        self, req: connectrpc.conformance.v1.service_pb2.IdempotentUnaryRequest,extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None
+        self, req: connectrpc.conformance.v1.service_pb2.IdempotentUnaryRequest, extra_headers: HeaderInput | None=None, timeout_seconds: float | None=None
     ) -> UnaryOutput[connectrpc.conformance.v1.service_pb2.IdempotentUnaryResponse]:
         """Low-level method to call IdempotentUnary, granting access to errors and metadata"""
         url = self.base_url + "/connectrpc.conformance.v1.ConformanceService/IdempotentUnary"


### PR DESCRIPTION
Replaced by generating using the BSR module, pinned to a tag.

Signed-off-by: Stefan VanBuren <svanburen@buf.build>
