### PR TITLE
Rename plugin to protoc-gen-connect-python

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ easiest using buf, but you can also use protoc if you're feeling
 masochistic.
 
 Install the compiler (e.g. `pip install connect-python[compiler]`), and
-it can be referenced as `protoc-gen-connect_python`.
+it can be referenced as `protoc-gen-connect-python`.
 
 A reasonable `buf.gen.yaml`:
 ```yaml
@@ -38,7 +38,7 @@ plugins:
     out: .
   - remote: buf.build/protocolbuffers/pyi
     out: .
-  - local: .venv/bin/protoc-gen-connect_python
+  - local: .venv/bin/protoc-gen-connect-python
     out: .
 ```
 
@@ -426,7 +426,7 @@ Set up development dependencies:
 uv sync --extra dev --extra compiler
 ```
 
-Install the package in editable mode to produce a local `protoc-gen-connect_python` plugin for use with `protoc`:
+Install the package in editable mode to produce a local `protoc-gen-connect-python` plugin for use with `protoc`:
 ```sh
 uv pip install -e .[compiler]
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ With a protobuf definition in hand, you can generate a client. This is
 easiest using buf, but you can also use protoc directly.
 
 Install the compiler (eg `pip install connect-python[compiler]`), and
-it can be referenced as `protoc-gen-connect_python`.
+it can be referenced as `protoc-gen-connect-python`.
 
 ### Using Buf (Recommended)
 
@@ -34,14 +34,14 @@ plugins:
     out: .
   - remote: buf.build/protocolbuffers/pyi
     out: .
-  - local: .venv/bin/protoc-gen-connect_python
+  - local: .venv/bin/protoc-gen-connect-python
     out: .
 ```
 
 ### Using protoc
 
 ```bash
-protoc --plugin=protoc-gen-connect_python=.venv/bin/protoc-gen-connect_python \
+protoc --plugin=protoc-gen-connect-python=.venv/bin/protoc-gen-connect-python \
        --connect_python_out=. \
        --python_out=. \
        --pyi_out=. \

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,7 @@ easiest using buf, but you can also use protoc if you're feeling
 masochistic.
 
 Install the compiler (eg `pip install connect-python[compiler]`), and
-it can be referenced as `protoc-gen-connect_python`.
+it can be referenced as `protoc-gen-connect-python`.
 
 A reasonable `buf.gen.yaml`:
 ```yaml
@@ -56,7 +56,7 @@ plugins:
     out: .
   - remote: buf.build/protocolbuffers/pyi
     out: .
-  - local: .venv/bin/protoc-gen-connect_python
+  - local: .venv/bin/protoc-gen-connect-python
     out: .
 ```
 

--- a/examples/buf.gen.yaml
+++ b/examples/buf.gen.yaml
@@ -4,5 +4,5 @@ plugins:
     out: .
   - remote: buf.build/protocolbuffers/pyi
     out: .
-  - local: ../.venv/bin/protoc-gen-connect_python
+  - local: ../.venv/bin/protoc-gen-connect-python
     out: .

--- a/justfile
+++ b/justfile
@@ -33,7 +33,7 @@ integration-test:
 
 # Run protoc with connect_python plugin (development mode). usage: uv run just protoc-gen [PROTOC_ARGS...]
 protoc-gen *ARGS:
-    protoc --plugin=protoc-gen-connect_python=.venv/bin/protoc-gen-connect_python {{ ARGS }}
+    protoc --plugin=protoc-gen-connect-python=.venv/bin/protoc-gen-connect-python {{ ARGS }}
 
 generate:
     cd tests/conformance && buf generate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ dev = [
 ]
 
 [project.scripts]
-protoc-gen-connect_python = "connectrpc.protoc_gen_connect_python.main:main"
+protoc-gen-connect-python = "connectrpc.protoc_gen_connect_python.main:main"
 
 [project.urls]
 Homepage = "https://github.com/connectrpc/connect-python"

--- a/tests/conformance/buf.gen.yaml
+++ b/tests/conformance/buf.gen.yaml
@@ -4,7 +4,7 @@ plugins:
     out: .
   - remote: buf.build/protocolbuffers/pyi
     out: .
-  - local: ../../.venv/bin/protoc-gen-connect_python
+  - local: ../../.venv/bin/protoc-gen-connect-python
     out: .
 inputs:
   - module: buf.build/connectrpc/conformance:v1.0.4


### PR DESCRIPTION
Makes the plugin name more consistent with the other Connect RPC plugins (and probably most protobuf plugins in general).

No strong feeling about this, as I see that e.g. the [mypy-protobuf plugins][1] use underscores as well, so if this is somehow easier to use in Python I think it's fine to not rename it.

Resolves #19.

[1]: https://github.com/nipunn1313/mypy-protobuf