### PR TITLE
Fix: Add workdir to goreleaser action for protoc-gen-connect-python build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,7 @@ jobs:
         with:
           version: "~> v2"
           args: release --clean
+          workdir: protoc-gen-connect-python
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
This PR fixes [the release workflow build failure](https://github.com/connectrpc/connect-python/actions/runs/17930515893/job/50986591111) by specifying the correct working directory for GoReleaser.

