### PR TITLE
Switch to "real" dev dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",
@@ -32,8 +33,8 @@ Homepage = "https://github.com/connectrpc/connect-python"
 Repository = "https://github.com/connectrpc/connect-python"
 Issues = "https://github.com/connectrpc/connect-python/issues"
 
-[tool.uv]
-dev-dependencies = [
+[dependency-groups]
+dev = [
     "asgiref",
     "brotli",
     "connect-python-example",


### PR DESCRIPTION
The old dev-dependencies group under [tool.uv] is deprecated in newer versions of `uv`.

Also, add 3.13 to the trove classifiers - can add 3.14 once it's released properly?

Ref: https://docs.astral.sh/uv/concepts/projects/dependencies/#development-dependencies