### PR TITLE
Cleanup protoc-gen-connect-python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,3 +18,12 @@ updates:
       python:
         patterns:
           - "*"
+  - package-ecosystem: gomod
+    directories:
+      - "protoc-gen-connect-python/"
+    schedule:
+      interval: weekly
+    groups:
+      go:
+        patterns:
+          - "*"

--- a/protoc-gen-connect-python/generator/generator.go
+++ b/protoc-gen-connect-python/generator/generator.go
@@ -8,17 +8,17 @@ import (
 	"strings"
 	"unicode"
 
-	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/reflect/protodesc"
 	"google.golang.org/protobuf/reflect/protoreflect"
 	"google.golang.org/protobuf/types/descriptorpb"
+	"google.golang.org/protobuf/types/pluginpb"
 )
 
-func Generate(r *plugin.CodeGeneratorRequest) *plugin.CodeGeneratorResponse {
-	resp := &plugin.CodeGeneratorResponse{}
+func Generate(r *pluginpb.CodeGeneratorRequest) *pluginpb.CodeGeneratorResponse {
+	resp := &pluginpb.CodeGeneratorResponse{}
 
-	resp.SupportedFeatures = proto.Uint64(uint64(plugin.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL) | uint64(plugin.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS))
+	resp.SupportedFeatures = proto.Uint64(uint64(pluginpb.CodeGeneratorResponse_FEATURE_PROTO3_OPTIONAL) | uint64(pluginpb.CodeGeneratorResponse_FEATURE_SUPPORTS_EDITIONS))
 	resp.MinimumEdition = proto.Int32(int32(descriptorpb.Edition_EDITION_PROTO3))
 	resp.MaximumEdition = proto.Int32(int32(descriptorpb.Edition_EDITION_2023))
 
@@ -60,7 +60,7 @@ func Generate(r *plugin.CodeGeneratorRequest) *plugin.CodeGeneratorResponse {
 	return resp
 }
 
-func GenerateConnectFile(fd protoreflect.FileDescriptor, conf Config) (*plugin.CodeGeneratorResponse_File, error) {
+func GenerateConnectFile(fd protoreflect.FileDescriptor, conf Config) (*pluginpb.CodeGeneratorResponse_File, error) {
 	filename := fd.Path()
 
 	fileNameWithoutSuffix := strings.TrimSuffix(filename, path.Ext(filename))
@@ -131,7 +131,7 @@ func GenerateConnectFile(fd protoreflect.FileDescriptor, conf Config) (*plugin.C
 		return nil, err
 	}
 
-	resp := &plugin.CodeGeneratorResponse_File{
+	resp := &pluginpb.CodeGeneratorResponse_File{
 		Name:    proto.String(strings.TrimSuffix(filename, path.Ext(filename)) + "_connect.py"),
 		Content: proto.String(buf.String()),
 	}

--- a/protoc-gen-connect-python/go.mod
+++ b/protoc-gen-connect-python/go.mod
@@ -2,9 +2,6 @@ module github.com/connectrpc/connect-python/protoc-gen-connect-python
 
 go 1.24.3
 
-require (
-	github.com/golang/protobuf v1.5.4
-	google.golang.org/protobuf v1.36.8
-)
+require google.golang.org/protobuf v1.36.8
 
 require github.com/google/go-cmp v0.7.0 // indirect

--- a/protoc-gen-connect-python/go.sum
+++ b/protoc-gen-connect-python/go.sum
@@ -1,5 +1,3 @@
-github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=
-github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 google.golang.org/protobuf v1.36.8 h1:xHScyCOEuuwZEc6UtSOvPbAT4zRh0xcNRYekJwfqyMc=

--- a/protoc-gen-connect-python/main.go
+++ b/protoc-gen-connect-python/main.go
@@ -5,8 +5,8 @@ import (
 	"log"
 	"os"
 
-	plugin "github.com/golang/protobuf/protoc-gen-go/plugin"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/pluginpb"
 
 	"github.com/connectrpc/connect-python/protoc-gen-connect-python/generator"
 )
@@ -17,7 +17,7 @@ func main() {
 		log.Fatalln("could not read from stdin", err)
 		return
 	}
-	var req = &plugin.CodeGeneratorRequest{}
+	req := &pluginpb.CodeGeneratorRequest{}
 	err = proto.Unmarshal(data, req)
 	if err != nil {
 		log.Fatalln("could not unmarshal proto", err)
@@ -30,7 +30,7 @@ func main() {
 	resp := generator.Generate(req)
 
 	if resp == nil {
-		resp = &plugin.CodeGeneratorResponse{}
+		resp = &pluginpb.CodeGeneratorResponse{}
 	}
 
 	data, err = proto.Marshal(resp)

--- a/protoc-gen-connect-python/pyproject.toml
+++ b/protoc-gen-connect-python/pyproject.toml
@@ -6,7 +6,7 @@ maintainers = [
     { name = "Anuraag Agrawal", email = "anuraaga@gmail.com" },
     { name = "Spencer Nelson", email = "spencer@firetiger.com" },
     { name = "Stefan VanBuren", email = "svanburen@buf.build" },
-    { name = "Yasushi Itoh", email = "i2y@todo" },
+    { name = "Yasushi Itoh", email = "i2y.may.roku@gmail.com" },
 ]
 requires-python = ">= 3.10"
 readme = "README.md"
@@ -47,8 +47,8 @@ Homepage = "https://github.com/connectrpc/connect-python"
 Repository = "https://github.com/connectrpc/connect-python"
 Issues = "https://github.com/connectrpc/connect-python/issues"
 
-[tool.uv]
-dev-dependencies = ["wheel"]
+[dependency-groups]
+dev = ["wheel"]
 
 [build-system]
 requires = ["uv_build>=0.8.13,<0.9.0"]


### PR DESCRIPTION
Just some minor cleanup, even if we decide to eventually move to writing the plugin in Python.

* Remove old dependency
* Update to non-deprecated dev dependencies
* Fix maintainer email
* Add Dependabot configuration for Go