### PR TITLE
Add doc for client metadata interceptor

### DIFF
--- a/docs/interceptors.md
+++ b/docs/interceptors.md
@@ -193,7 +193,7 @@ An authentication interceptor checking bearer tokens and storing them to a conte
             if not authorization or not authorization.startswith("Bearer "):
                 raise ConnectError(Code.UNAUTHENTICATED)
             token = authorization[len("Bearer "):]
-            if token not in valid_tokens:
+            if token not in self._valid_tokens:
                 raise ConnectError(Code.PERMISSION_DENIED)
             return _auth_token.set(token)
 
@@ -217,7 +217,7 @@ An authentication interceptor checking bearer tokens and storing them to a conte
             if not authorization or not authorization.startswith("Bearer "):
                 raise ConnectError(Code.UNAUTHENTICATED)
             token = authorization[len("Bearer "):]
-            if token not in valid_tokens:
+            if token not in self._valid_tokens:
                 raise ConnectError(Code.PERMISSION_DENIED)
             return _auth_token.set(token)
 


### PR DESCRIPTION
#28 gave the idea of fleshing out the auth interceptors to propagate the auth token from server to client. Since the two interceptors demonstrate the two forms of on_end or not, I removed the timing interceptor.

Fixes #28

/cc @rockwotj thanks for the idea!