### PR TITLE
Support Python 3.14

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,7 +28,7 @@ jobs:
           - windows-2025
         python:
           - "3.10"
-          - "3.13"
+          - "3.14"
         coverage:
           - "nocov"
         # Test oldest and newest on all OS's, but others only on one
@@ -42,14 +42,14 @@ jobs:
             python: "3.12"
             coverage: "nocov"
             resolution: "lowest-direct"
-          # Enable coverage on just one job
           - os: ubuntu-24.04
             python: "3.13"
-            coverage: "cov"
-            resolution: "lowest-direct"
-          - os: ubuntu-24.04
-            python: "3.14.0-rc.2"
             coverage: "nocov"
+            resolution: "lowest-direct"
+          # Enable coverage on just one job
+          - os: ubuntu-24.04
+            python: "3.14"
+            coverage: "cov"
             resolution: "lowest-direct"
     env:
       # Shared env variables for all the tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Topic :: Internet :: WWW/HTTP",
     "Topic :: Software Development :: Libraries :: Python Modules",
     "Typing :: Typed",


### PR DESCRIPTION
Released [yesterday](https://devguide.python.org/versions/#supported-versions).

Looking at the release notes, it looks like maybe the only thing we may want to get in here is the [zstandard support in the stdlib](https://docs.python.org/3.14/whatsnew/3.14.html#pep-784-zstandard-support-in-the-standard-library), i.e. [drop the dependency for 3.14](https://github.com/connectrpc/connect-python/blob/5bae39f5aebbd87439be0860a8be114f10ac7b4b/pyproject.toml#L53) and just have support on by default?