### PR TITLE
Add security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,5 @@
+Security Policy
+===============
+
+This project follows the [Connect security policy and reporting
+process](https://connectrpc.com/docs/governance/security).


### PR DESCRIPTION
Matching the contents of the policy from connect-go; added to the `.github/` directory with the other GitHub-specific bits.

Ref: https://github.com/connectrpc/connect-go/blob/main/SECURITY.md