### PR TITLE
Update some instructions in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -11,7 +11,7 @@ This document outlines how to create a release of connect-python.
 
 Note the new version X.Y.Z in the updated files.
 
-3. Open a PR titled "Prepare for vX.Y.Z" ([Example PR #60](https://github.com/connectrpc/connect-python/pull/60)) and assign all current maintainers as reviewers. Once it's approved by at
+3. Open a PR titled "Prepare for vX.Y.Z" ([Example PR #60](https://github.com/connectrpc/connect-python/pull/60)) and assign the `connectrpc/python` group as reviewers. Once it's approved by at
    least one other maintainer and CI passes, merge it.
 
    _Make sure no new commits are merged until the release is complete._


### PR DESCRIPTION
A couple points I thought it's worth clarifying on the release doc

- I figure it's better to use the Reviewers feature rather than mentioning in description
- I made clear at least one other maintainer needs to approve the release PR. I'm happy to change that to any number that works, I wasn't sure what was intended when copying from connect-go