### PR TITLE
Upgrade to pytest 9.0

### DIFF
--- a/justfile
+++ b/justfile
@@ -22,11 +22,11 @@ typecheck:
 # Run unit tests with no extras
 [working-directory: 'noextras']
 test-noextras *args:
-    uv run --exact pytest {{args}}
+    uv run --exact pytest -W error {{args}}
 
 # Run unit tests
 test *args: (test-noextras args)
-    uv run pytest {{args}}
+    uv run pytest -W error {{args}}
 
 # Run lint, typecheck and test
 check: lint typecheck test

--- a/noextras/pyproject.toml
+++ b/noextras/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
   "pytest",
   "pytest-asyncio",
   "pytest-cov",
+  "pytest-timeout",
 ]
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,6 @@ dev = [
     "mkdocstrings[python]==0.30.1",
     "pyqwest==0.1.0",
     "pyright[nodejs]==1.1.405",
-    "pytest-timeout==2.4.0",
     "pyvoy==0.2.0",
     "ruff~=0.13.2",
     "uvicorn==0.37.0",
@@ -65,6 +64,7 @@ dev = [
     "pytest",
     "pytest-asyncio",
     "pytest-cov",
+    "pytest-timeout",
 ]
 
 [build-system]
@@ -74,17 +74,19 @@ build-backend = "uv_build"
 [tool.uv]
 resolution = "lowest-direct"
 constraint-dependencies = [
-    "pytest==8.4.2",
-    "pytest-asyncio==1.2.0",
+    "pytest==9.0.2",
+    "pytest-asyncio==1.3.0",
     "pytest-cov==7.0.0",
+    "pytest-timeout==2.4.0",
 ]
 
 [tool.uv.build-backend]
 module-name = "connectrpc"
 
-[tool.pytest.ini_options]
+[tool.pytest]
+strict = true
 testpaths = ["test"]
-timeout = 1800       # 30 min
+timeout = "1800" # 30 min
 
 [tool.ruff.format]
 skip-magic-trailing-comma = true

--- a/uv.lock
+++ b/uv.lock
@@ -16,9 +16,10 @@ members = [
     "connect-python-noextras",
 ]
 constraints = [
-    { name = "pytest", specifier = "==8.4.2" },
-    { name = "pytest-asyncio", specifier = "==1.2.0" },
+    { name = "pytest", specifier = "==9.0.2" },
+    { name = "pytest-asyncio", specifier = "==1.3.0" },
     { name = "pytest-cov", specifier = "==7.0.0" },
+    { name = "pytest-timeout", specifier = "==2.4.0" },
 ]
 
 [[package]]
@@ -507,7 +508,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
-    { name = "pytest-timeout", specifier = "==2.4.0" },
+    { name = "pytest-timeout" },
     { name = "pyvoy", specifier = "==0.2.0" },
     { name = "ruff", specifier = "~=0.13.2" },
     { name = "twisted", extras = ["tls", "http2"], specifier = "==25.5.0" },
@@ -545,6 +546,7 @@ dependencies = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
 ]
 
 [package.metadata]
@@ -554,6 +556,7 @@ requires-dist = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
+    { name = "pytest-timeout" },
 ]
 
 [[package]]
@@ -1927,7 +1930,7 @@ nodejs = [
 
 [[package]]
 name = "pytest"
-version = "8.4.2"
+version = "9.0.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1938,23 +1941,23 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.2.0"
+version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/86/9e3c5f48f7b7b638b216e4b9e645f54d199d7abbbab7a64a13b4e12ba10f/pytest_asyncio-1.2.0.tar.gz", hash = "sha256:c609a64a2a8768462d0c99811ddb8bd2583c33fd33cf7f21af1c142e824ffb57", size = 50119, upload-time = "2025-09-12T07:33:53.816Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/04/93/2fa34714b7a4ae72f2f8dad66ba17dd9a2c793220719e736dda28b7aec27/pytest_asyncio-1.2.0-py3-none-any.whl", hash = "sha256:8e17ae5e46d8e7efe51ab6494dd2010f4ca8dae51652aa3c8d55acf50bfb2e99", size = 15095, upload-time = "2025-09-12T07:33:52.639Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Bumps us to using pytest 9.0, which needed another version bump or two. Enabled pytest's new `strict` mode, and turned warnings into errors (we had a warning showing in the no-extras tests, because we weren't including pytest-timeout in that workspace).

Not sure if it's worth changing any of the parameterized tests into subtests (as I imagine they're more I/O bound than anything?), but could do as a follow-up.

Ref: https://docs.pytest.org/en/stable/changelog.html#pytest-9-0-0-2025-11-05