### PR TITLE
Align compression levels with Envoy

### DIFF
--- a/src/connectrpc/_compression.py
+++ b/src/connectrpc/_compression.py
@@ -45,7 +45,7 @@ try:
             return "br"
 
         def compress(self, data: bytes | bytearray) -> bytes:
-            return brotli.compress(data, quality=6)
+            return brotli.compress(data, quality=3)
 
         def decompress(self, data: bytes | bytearray) -> bytes:
             return brotli.decompress(data)


### PR DESCRIPTION
Currently, gzip compression, our default, uses Python's default of level 9 which is for long term storage like OS packages and not good for network servers. 

I wanted to align with some standard for defaults, and went with Envoy where [brotli=3](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/compression/brotli/compressor/v3/brotli.proto#envoy-v3-api-msg-extensions-compression-brotli-compressor-v3-brotli), [gzip=6](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/compression/gzip/compressor/v3/gzip.proto), [zstd=3](https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/compression/zstd/compressor/v3/zstd.proto)

For reference, connect-go uses the defaults for the Go libraries for all compressions (zstd / brotli are within the conformance runner), which are level=6 for [gzip](https://cs.opensource.google/go/go/+/refs/tags/go1.25.6:src/compress/flate/deflate.go;l=589) and [brotli](https://github.com/andybalholm/brotli/blob/master/writer.go#L13C2-L13C20), and default (level 3) for zstd.

As gzip is used by default, this is probably closer to a bug than performance enhancement

#96