### PR TITLE
Set codecov token in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -99,6 +99,8 @@ jobs:
 
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         if: ${{ matrix.coverage == 'cov' }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
 
   publish:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
While codecov supports tokenless upload for public repos, it seems toggling that requires org admin permissions. Rather than bothering the admins, it's easy to just set the token