### PR TITLE
Process GET params for empty request messages

### DIFF
--- a/src/connectrpc/_client_shared.py
+++ b/src/connectrpc/_client_shared.py
@@ -30,11 +30,12 @@ RES = TypeVar("RES")
 def prepare_get_params(
     codec: Codec, request_data: bytes, headers: HTTPHeaders
 ) -> dict[str, str]:
-    params = {"connect": f"v{CONNECT_PROTOCOL_VERSION}"}
-    if request_data:
-        params["message"] = base64.urlsafe_b64encode(request_data).decode("ascii")
-        params["base64"] = "1"
-        params["encoding"] = codec.name()
+    params = {
+        "connect": f"v{CONNECT_PROTOCOL_VERSION}",
+        "message": base64.urlsafe_b64encode(request_data).decode("ascii"),
+        "base64": "1",
+        "encoding": codec.name(),
+    }
     if "content-encoding" in headers:
         params["compression"] = headers.pop("content-encoding")
     return params

--- a/src/connectrpc/_server_async.py
+++ b/src/connectrpc/_server_async.py
@@ -194,7 +194,7 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
 
             if http_method == "GET":
                 query_string = scope.get("query_string", b"").decode("utf-8")
-                query_params = parse_qs(query_string)
+                query_params = parse_qs(query_string, keep_blank_values=True)
                 codec_name = query_params.get("encoding", ("",))[0]
             else:
                 query_params = _UNSET_QUERY_PARAMS

--- a/src/connectrpc/_server_sync.py
+++ b/src/connectrpc/_server_sync.py
@@ -353,7 +353,7 @@ class ConnectWSGIApplication(ABC):
         """Handle GET request with query parameters."""
         try:
             query_string = environ.get("QUERY_STRING", "")
-            params = parse_qs(query_string)
+            params = parse_qs(query_string, keep_blank_values=True)
 
             if "message" not in params:
                 raise ConnectError(


### PR DESCRIPTION
They are valid protobuf, otherwise we get errors like

```json
{
    "code": "invalid_argument",
    "message": "'message' parameter is required for GET requests"
}
```