### PR TITLE
Specify python version to setup-uv

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,8 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - uses: astral-sh/setup-uv@eac588ad8def6316056a12d4907a9d4d84ff7a3b # v7.3.0
+        with:
+          python-version: ${{ matrix.python }}
 
       - uses: actions/setup-go@7a3fe6cf4cb3a834922a1244abfce67bcef6a0c5 # v6.2.0
         with:


### PR DESCRIPTION
When reviewing #120 I recall explicitly noticing the setup-python step for the actual tests was still there, making sure they run with the correct python, but I must have misread it. That was important to keep, and I noticed that currently all tests are run with Python 3.12, sorry for missing it.

As a compromise, I've gone ahead and just set the python version to setup-uv without an additional step to see how it goes