### PR TITLE
Add BUF_TOKEN to checkgenerate environment

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,6 +92,8 @@ jobs:
         # We expect uv.lock to change when matrix.resolution == "highest", so we don't check it there.
         if: ${{ startsWith(matrix.os, 'macos-') && matrix.resolution == 'lowest-direct' }}
         run: uv run just checkgenerate
+        env:
+          BUF_TOKEN: ${{ secrets.BUF_TOKEN }}
 
       - uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.2
         if: ${{ matrix.coverage == 'cov' }}


### PR DESCRIPTION
To avoid rate limits from remote plugins.

Ref: https://github.com/connectrpc/connect-python/actions/runs/22338170666/job/64635401847?pr=138