### PR TITLE
Migrate attest github action to current repo

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -42,7 +42,7 @@ jobs:
           uv run python scripts/generate_wheels.py
         working-directory: protoc-gen-connect-python
 
-      - uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+      - uses: actions/attest@59d89421af93a897026c735860bf21b6eb4f7b26 # v4.1.0
         with:
           subject-checksums: out/checksums.txt
 


### PR DESCRIPTION
#145

> As of version 4, actions/attest-build-provenance is simply a wrapper on top of [actions/attest](https://redirect.github.com/actions/attest). Existing applications may continue to use the attest-build-provenance action, but new implementations should use actions/attest instead.