### PR TITLE
Add Documentation link to project.urls for PyPI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 Homepage = "https://github.com/connectrpc/connect-python"
 Repository = "https://github.com/connectrpc/connect-python"
 Issues = "https://github.com/connectrpc/connect-python/issues"
+Documentation = "https://connectrpc.com/docs/python/getting-started/"
 
 [dependency-groups]
 dev = [


### PR DESCRIPTION
Seems reasonable now that we have hosted docs.

Ref: https://packaging.python.org/en/latest/specifications/well-known-project-urls/#well-known-labels