### PR TITLE
Update ruff `extend-ignore` key to `ignore`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,7 +152,7 @@ extend-select = [
 ]
 
 # Document reasons for ignoring specific linting errors
-extend-ignore = [
+ignore = [
     # Not applicable
     "AIR",
     # Dangerous false positives https://github.com/astral-sh/ruff/issues/4845


### PR DESCRIPTION
Deprecated, and now interchangeable with ignore.

Ref: https://docs.astral.sh/ruff/settings/#lint_extend-ignore