### PR TITLE
Match all update types for dependencies and bump Go

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
   "packageRules": [
     {
       "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["*"],
       "groupName": "GitHub Actions"
     },
     {
@@ -23,10 +24,13 @@
     },
     {
       "matchCategories": ["python"],
+      "matchUpdateTypes": ["*"],
       "groupName": "Python dependencies"
     },
     {
       "matchDatasources": ["golang-version"],
+      "rangeStrategy": "bump",
+      "allowedVersions": "/^1\\.25\\.0$/",
       "groupName": "Go"
     },
     {


### PR DESCRIPTION
When looking at #156, I think the issue is that the conflicting opentelemetry-instrumentation-asgi is considered a major version update so wants to be in a separate PR from the opentelemetry-sdk minor update, which isn't possible due to the conflict. Anyways, since these are only dev dependencies, there isn't a big advantage to separating major and minor PRs so have tried to group them together. Notably lock file maintenance should also end up in the same PR which I think is convenient

Also did same to GitHub actions because major updates there are often about NodeJS versions etc and hardly ever need code fixes to warrant separate PRs.

And while at it, set renovate to automatically bump Go version to n-1.