### PR TITLE
Add json_codec parameter for customizable ProtoJSONCodec

### DIFF
--- a/conformance/test/gen/connectrpc/conformance/v1/service_connect.py
+++ b/conformance/test/gen/connectrpc/conformance/v1/service_connect.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         Mapping,
     )
 
+    from connectrpc import ProtoJSONCodec
     from connectrpc.compression import Compression
     from connectrpc.interceptor import Interceptor, InterceptorSync
     from connectrpc.request import Headers, RequestContext
@@ -91,6 +92,7 @@ class ConformanceServiceASGIApplication(ConnectASGIApplication[ConformanceServic
         interceptors: Iterable[Interceptor] = (),
         read_max_bytes: int | None = None,
         compressions: Iterable[Compression] | None = None,
+        json_codec: ProtoJSONCodec | None = None,
     ) -> None:
         super().__init__(
             service=service,
@@ -159,6 +161,7 @@ class ConformanceServiceASGIApplication(ConnectASGIApplication[ConformanceServic
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            json_codec=json_codec,
         )
 
     @property
@@ -358,6 +361,8 @@ class ConformanceServiceWSGIApplication(ConnectWSGIApplication):
         interceptors: Iterable[InterceptorSync] = (),
         read_max_bytes: int | None = None,
         compressions: Iterable[Compression] | None = None,
+        *,
+        json_codec: ProtoJSONCodec | None = None,
     ) -> None:
         super().__init__(
             endpoints={
@@ -425,6 +430,7 @@ class ConformanceServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            json_codec=json_codec,
         )
 
     @property

--- a/example/example/eliza_connect.py
+++ b/example/example/eliza_connect.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
         Mapping,
     )
 
+    from connectrpc import ProtoJSONCodec
     from connectrpc.compression import Compression
     from connectrpc.interceptor import Interceptor, InterceptorSync
     from connectrpc.request import Headers, RequestContext
@@ -58,6 +59,7 @@ class ElizaServiceASGIApplication(ConnectASGIApplication[ElizaService]):
         interceptors: Iterable[Interceptor] = (),
         read_max_bytes: int | None = None,
         compressions: Iterable[Compression] | None = None,
+        json_codec: ProtoJSONCodec | None = None,
     ) -> None:
         super().__init__(
             service=service,
@@ -96,6 +98,7 @@ class ElizaServiceASGIApplication(ConnectASGIApplication[ElizaService]):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            json_codec=json_codec,
         )
 
     @property
@@ -194,6 +197,8 @@ class ElizaServiceWSGIApplication(ConnectWSGIApplication):
         interceptors: Iterable[InterceptorSync] = (),
         read_max_bytes: int | None = None,
         compressions: Iterable[Compression] | None = None,
+        *,
+        json_codec: ProtoJSONCodec | None = None,
     ) -> None:
         super().__init__(
             endpoints={
@@ -231,6 +236,7 @@ class ElizaServiceWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            json_codec=json_codec,
         )
 
     @property

--- a/protoc-gen-connect-python/generator/template.go
+++ b/protoc-gen-connect-python/generator/template.go
@@ -54,6 +54,7 @@ from connectrpc.errors import ConnectError
 from connectrpc.interceptor import Interceptor, InterceptorSync
 from connectrpc.method import IdempotencyLevel, MethodInfo
 from connectrpc.request import Headers, RequestContext
+from connectrpc import ProtoJSONCodec
 from connectrpc.server import ConnectASGIApplication, ConnectWSGIApplication, Endpoint, EndpointSync
 
 {{- range .Imports }}
@@ -69,7 +70,7 @@ class {{.Name}}(Protocol):{{- range .Methods }}
 {{ end }}
 
 class {{.Name}}ASGIApplication(ConnectASGIApplication[{{.Name}}]):
-    def __init__(self, service: {{.Name}} | AsyncGenerator[{{.Name}}], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: {{.Name}} | AsyncGenerator[{{.Name}}], *, interceptors: Iterable[Interceptor]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, json_codec: ProtoJSONCodec | None = None) -> None:
         super().__init__(
             service=service,
             endpoints=lambda svc: { {{- range .Methods }}
@@ -87,6 +88,7 @@ class {{.Name}}ASGIApplication(ConnectASGIApplication[{{.Name}}]):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            json_codec=json_codec,
         )
 
     @property
@@ -130,7 +132,7 @@ class {{.Name}}Sync(Protocol):{{- range .Methods }}
 
 
 class {{.Name}}WSGIApplication(ConnectWSGIApplication):
-    def __init__(self, service: {{.Name}}Sync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None) -> None:
+    def __init__(self, service: {{.Name}}Sync, interceptors: Iterable[InterceptorSync]=(), read_max_bytes: int | None = None, compressions: Iterable[Compression] | None = None, *, json_codec: ProtoJSONCodec | None = None) -> None:
         super().__init__(
             endpoints={ {{- range .Methods }}
                 "/{{.ServiceName}}/{{.Name}}": EndpointSync.{{.EndpointType}}(
@@ -147,6 +149,7 @@ class {{.Name}}WSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            json_codec=json_codec,
         )
 
     @property

--- a/src/connectrpc/__init__.py
+++ b/src/connectrpc/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-__all__ = ["__version__"]
+__all__ = ["MarshalOptions", "ProtoJSONCodec", "__version__"]
 
-
+from ._codec import MarshalOptions, ProtoJSONCodec
 from ._version import __version__

--- a/src/connectrpc/_client_async.py
+++ b/src/connectrpc/_client_async.py
@@ -12,7 +12,7 @@ from pyqwest import Headers as HTTPHeaders
 
 from . import _client_shared
 from ._asyncio_timeout import timeout as asyncio_timeout
-from ._codec import Codec, get_proto_binary_codec, get_proto_json_codec
+from ._codec import Codec, ProtoJSONCodec, get_proto_binary_codec, get_proto_json_codec
 from ._compression import IdentityCompression, _gzip, resolve_compressions
 from ._interceptor_async import (
     BidiStreamInterceptor,
@@ -100,6 +100,7 @@ class ConnectClient:
         read_max_bytes: int | None = None,
         interceptors: Iterable[Interceptor] = (),
         http_client: HTTPClient | None = None,
+        json_codec: ProtoJSONCodec | None = None,
     ) -> None:
         """Creates a new asynchronous Connect client.
 
@@ -115,9 +116,18 @@ class ConnectClient:
             read_max_bytes: The maximum number of bytes to read from the response.
             interceptors: A list of interceptors to apply to requests.
             http_client: A pyqwest Client to use for requests.
+            json_codec: Custom JSON codec. Requires ``proto_json=True``.
         """
+        if json_codec is not None and not proto_json:
+            msg = "json_codec requires proto_json=True"
+            raise ValueError(msg)
         self._address = address
-        self._codec = get_proto_json_codec() if proto_json else get_proto_binary_codec()
+        if proto_json:
+            self._codec: Codec = (
+                json_codec if json_codec is not None else get_proto_json_codec()
+            )
+        else:
+            self._codec = get_proto_binary_codec()
         self._response_compressions = resolve_compressions(accept_compression)
         self._accept_compression_header = ",".join(self._response_compressions.keys())
         self._send_compression = send_compression or IdentityCompression()

--- a/src/connectrpc/_client_sync.py
+++ b/src/connectrpc/_client_sync.py
@@ -10,7 +10,7 @@ from pyqwest import Headers as HTTPHeaders
 from connectrpc._protocol_grpc import GRPCClientProtocol, GRPCWebClientProtocol
 
 from . import _client_shared
-from ._codec import Codec, get_proto_binary_codec, get_proto_json_codec
+from ._codec import Codec, ProtoJSONCodec, get_proto_binary_codec, get_proto_json_codec
 from ._compression import IdentityCompression, _gzip, resolve_compressions
 from ._interceptor_sync import (
     BidiStreamInterceptorSync,
@@ -90,6 +90,7 @@ class ConnectClientSync:
         read_max_bytes: int | None = None,
         interceptors: Iterable[InterceptorSync] = (),
         http_client: SyncClient | None = None,
+        json_codec: ProtoJSONCodec | None = None,
     ) -> None:
         """Creates a new synchronous Connect client.
 
@@ -105,9 +106,18 @@ class ConnectClientSync:
             read_max_bytes: The maximum number of bytes to read from the response.
             interceptors: A list of interceptors to apply to requests.
             http_client: A pyqwest SyncClient to use for requests.
+            json_codec: Custom JSON codec. Requires ``proto_json=True``.
         """
+        if json_codec is not None and not proto_json:
+            msg = "json_codec requires proto_json=True"
+            raise ValueError(msg)
         self._address = address
-        self._codec = get_proto_json_codec() if proto_json else get_proto_binary_codec()
+        if proto_json:
+            self._codec: Codec = (
+                json_codec if json_codec is not None else get_proto_json_codec()
+            )
+        else:
+            self._codec = get_proto_binary_codec()
         self._timeout_ms = timeout_ms
         self._read_max_bytes = read_max_bytes
         self._response_compressions = resolve_compressions(accept_compression)

--- a/src/connectrpc/_codec.py
+++ b/src/connectrpc/_codec.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
-from typing import Protocol, TypeVar
+from typing import TYPE_CHECKING, Protocol, TypedDict, TypeVar
 
 from google.protobuf.json_format import MessageToJson
 from google.protobuf.json_format import Parse as MessageFromJson
 from google.protobuf.message import Message
+
+if TYPE_CHECKING:
+    from google.protobuf.descriptor_pool import DescriptorPool
 
 CODEC_NAME_PROTO = "proto"
 CODEC_NAME_JSON = "json"
@@ -46,14 +49,34 @@ class ProtoBinaryCodec(Codec[Message, V]):
         return message
 
 
+class MarshalOptions(TypedDict, total=False):
+    """Options for ``MessageToJson`` serialization.
+
+    All fields are optional and correspond to the keyword arguments of
+    ``google.protobuf.json_format.MessageToJson``.
+    """
+
+    preserving_proto_field_name: bool
+    indent: int | None
+    sort_keys: bool
+    use_integers_for_enums: bool
+    float_precision: int | None
+    ensure_ascii: bool
+    always_print_fields_with_no_presence: bool
+    descriptor_pool: DescriptorPool | None
+
+
 class ProtoJSONCodec(Codec[Message, V]):
     """Codec for Protocol bytes | bytearrays JSON format."""
+
+    def __init__(self, *, marshal_options: MarshalOptions | None = None) -> None:
+        self._marshal_options: MarshalOptions = marshal_options or {}
 
     def name(self) -> str:
         return "json"
 
     def encode(self, message: Message) -> bytes:
-        return MessageToJson(message).encode()
+        return MessageToJson(message, **self._marshal_options).encode()
 
     def decode(self, data: bytes | bytearray, message: V) -> V:
         MessageFromJson(data, message)  # pyright: ignore[reportArgumentType] - type is incorrect

--- a/src/connectrpc/_server_async.py
+++ b/src/connectrpc/_server_async.py
@@ -11,7 +11,13 @@ from http import HTTPStatus
 from typing import TYPE_CHECKING, Generic, TypeVar, cast
 from urllib.parse import parse_qs
 
-from ._codec import Codec, get_codec
+from ._codec import (
+    CODEC_NAME_JSON,
+    CODEC_NAME_JSON_CHARSET_UTF8,
+    Codec,
+    ProtoJSONCodec,
+    get_codec,
+)
 from ._compression import negotiate_compression, resolve_compressions
 from ._envelope import EnvelopeReader
 from ._interceptor_async import (
@@ -91,6 +97,7 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
         interceptors: Iterable[Interceptor] = (),
         read_max_bytes: int | None = None,
         compressions: Iterable[Compression] | None = None,
+        json_codec: ProtoJSONCodec | None = None,
     ) -> None:
         """Initialize the ASGI application.
 
@@ -103,6 +110,9 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
             read_max_bytes: Maximum size of request messages.
             compressions: Supported compression algorithms. If unset, defaults to gzip.
                           If set to empty, disables compression.
+            json_codec: Custom JSON codec to use instead of the default. Allows
+                customizing ``MessageToJson`` options such as
+                ``always_print_fields_with_no_presence``.
         """
         super().__init__()
         self._service = service
@@ -111,6 +121,10 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
         self._resolved_endpoints = None
         self._read_max_bytes = read_max_bytes
         self._compressions = resolve_compressions(compressions)
+        self._codec_overrides: dict[str, Codec] = {}
+        if json_codec is not None:
+            self._codec_overrides[CODEC_NAME_JSON] = json_codec
+            self._codec_overrides[CODEC_NAME_JSON_CHARSET_UTF8] = json_codec
 
     async def __call__(
         self, scope: Scope, receive: ASGIReceiveCallable, send: ASGISendCallable
@@ -208,7 +222,8 @@ class ConnectASGIApplication(ABC, Generic[_SVC]):
                 codec_name = protocol.codec_name_from_content_type(
                     headers.get("content-type", ""), stream=not is_unary
                 )
-            codec = get_codec(codec_name.lower())
+            override = self._codec_overrides.get(codec_name.lower())
+            codec = override if override is not None else get_codec(codec_name.lower())
             if not codec:
                 raise HTTPException(
                     HTTPStatus.UNSUPPORTED_MEDIA_TYPE,

--- a/src/connectrpc/_server_sync.py
+++ b/src/connectrpc/_server_sync.py
@@ -9,7 +9,13 @@ from typing import TYPE_CHECKING, TypeVar
 from urllib.parse import parse_qs
 
 from . import _server_shared
-from ._codec import Codec, get_codec
+from ._codec import (
+    CODEC_NAME_JSON,
+    CODEC_NAME_JSON_CHARSET_UTF8,
+    Codec,
+    ProtoJSONCodec,
+    get_codec,
+)
 from ._compression import negotiate_compression, resolve_compressions
 from ._envelope import EnvelopeReader, EnvelopeWriter
 from ._interceptor_sync import (
@@ -168,6 +174,7 @@ class ConnectWSGIApplication(ABC):
         interceptors: Iterable[InterceptorSync] = (),
         read_max_bytes: int | None = None,
         compressions: Iterable[Compression] | None = None,
+        json_codec: ProtoJSONCodec | None = None,
     ) -> None:
         """Initialize the WSGI application.
 
@@ -178,6 +185,9 @@ class ConnectWSGIApplication(ABC):
             read_max_bytes: Maximum size of request messages.
             compressions: Supported compression algorithms. If unset, defaults to gzip.
                           If set to empty, disables compression.
+            json_codec: Custom JSON codec to use instead of the default. Allows
+                customizing ``MessageToJson`` options such as
+                ``always_print_fields_with_no_presence``.
         """
         super().__init__()
         if interceptors:
@@ -194,6 +204,10 @@ class ConnectWSGIApplication(ABC):
         self._endpoints = endpoints
         self._read_max_bytes = read_max_bytes
         self._compressions = resolve_compressions(compressions)
+        self._codec_overrides: dict[str, Codec] = {}
+        if json_codec is not None:
+            self._codec_overrides[CODEC_NAME_JSON] = json_codec
+            self._codec_overrides[CODEC_NAME_JSON_CHARSET_UTF8] = json_codec
 
     def __call__(
         self, environ: WSGIEnvironment, start_response: StartResponse
@@ -299,7 +313,8 @@ class ConnectWSGIApplication(ABC):
         codec_name = codec_name_from_content_type(
             request_headers.get("content-type", ""), stream=False
         )
-        codec = get_codec(codec_name)
+        override = self._codec_overrides.get(codec_name)
+        codec = override if override is not None else get_codec(codec_name)
         if not codec:
             raise HTTPException(
                 HTTPStatus.UNSUPPORTED_MEDIA_TYPE,
@@ -393,7 +408,8 @@ class ConnectWSGIApplication(ABC):
                 message = compression.decompress(message)
 
             codec_name = params.get("encoding", ("",))[0]
-            codec = get_codec(codec_name)
+            override = self._codec_overrides.get(codec_name)
+            codec = override if override is not None else get_codec(codec_name)
             if not codec:
                 raise ConnectError(
                     Code.UNIMPLEMENTED, f"invalid message encoding: '{codec_name}'"
@@ -430,7 +446,8 @@ class ConnectWSGIApplication(ABC):
         codec_name = protocol.codec_name_from_content_type(
             headers.get("content-type", ""), stream=True
         )
-        codec = get_codec(codec_name)
+        override = self._codec_overrides.get(codec_name)
+        codec = override if override is not None else get_codec(codec_name)
         if not codec:
             raise HTTPException(
                 HTTPStatus.UNSUPPORTED_MEDIA_TYPE,

--- a/test/haberdasher_connect.py
+++ b/test/haberdasher_connect.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
         Mapping,
     )
 
+    from connectrpc import ProtoJSONCodec
     from connectrpc.compression import Compression
     from connectrpc.interceptor import Interceptor, InterceptorSync
     from connectrpc.request import Headers, RequestContext
@@ -73,6 +74,7 @@ class HaberdasherASGIApplication(ConnectASGIApplication[Haberdasher]):
         interceptors: Iterable[Interceptor] = (),
         read_max_bytes: int | None = None,
         compressions: Iterable[Compression] | None = None,
+        json_codec: ProtoJSONCodec | None = None,
     ) -> None:
         super().__init__(
             service=service,
@@ -141,6 +143,7 @@ class HaberdasherASGIApplication(ConnectASGIApplication[Haberdasher]):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            json_codec=json_codec,
         )
 
     @property
@@ -312,6 +315,8 @@ class HaberdasherWSGIApplication(ConnectWSGIApplication):
         interceptors: Iterable[InterceptorSync] = (),
         read_max_bytes: int | None = None,
         compressions: Iterable[Compression] | None = None,
+        *,
+        json_codec: ProtoJSONCodec | None = None,
     ) -> None:
         super().__init__(
             endpoints={
@@ -379,6 +384,7 @@ class HaberdasherWSGIApplication(ConnectWSGIApplication):
             interceptors=interceptors,
             read_max_bytes=read_max_bytes,
             compressions=compressions,
+            json_codec=json_codec,
         )
 
     @property

--- a/test/haberdasher_pb2.py
+++ b/test/haberdasher_pb2.py
@@ -15,7 +15,7 @@ _sym_db = _symbol_database.Default()
 from google.protobuf import empty_pb2 as google_dot_protobuf_dot_empty__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11haberdasher.proto\x12\x12\x63onnectrpc.example\x1a\x1bgoogle/protobuf/empty.proto\"i\n\x03Hat\x12\x12\n\x04size\x18\x01 \x01(\x05R\x04size\x12\x14\n\x05\x63olor\x18\x02 \x01(\tR\x05\x63olor\x12\x17\n\x04name\x18\x03 \x01(\tH\x00R\x04name\x88\x01\x01\x1a\x16\n\x04Part\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02idB\x07\n\x05_name\"@\n\x04Size\x12\x16\n\x06inches\x18\x01 \x01(\x05R\x06inches\x12 \n\x0b\x64\x65scription\x18\x02 \x01(\tR\x0b\x64\x65scription2\xb7\x03\n\x0bHaberdasher\x12\x41\n\x07MakeHat\x12\x18.connectrpc.example.Size\x1a\x17.connectrpc.example.Hat\"\x03\x90\x02\x01\x12H\n\x0fMakeFlexibleHat\x12\x18.connectrpc.example.Size\x1a\x17.connectrpc.example.Hat\"\x00(\x01\x12K\n\x0fMakeSimilarHats\x12\x18.connectrpc.example.Size\x1a\x17.connectrpc.example.Hat\"\x03\x90\x02\x01\x30\x01\x12J\n\x0fMakeVariousHats\x12\x18.connectrpc.example.Size\x1a\x17.connectrpc.example.Hat\"\x00(\x01\x30\x01\x12\x45\n\tListParts\x12\x16.google.protobuf.Empty\x1a\x1c.connectrpc.example.Hat.Part\"\x00\x30\x01\x12;\n\tDoNothing\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.EmptyB\tZ\x07\x65xampleb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x11haberdasher.proto\x12\x12\x63onnectrpc.example\x1a\x1bgoogle/protobuf/empty.proto\"}\n\x03Hat\x12\x12\n\x04size\x18\x01 \x01(\x05R\x04size\x12\x14\n\x05\x63olor\x18\x02 \x01(\tR\x05\x63olor\x12\x17\n\x04name\x18\x03 \x01(\tH\x00R\x04name\x88\x01\x01\x12\x12\n\x04tags\x18\x04 \x03(\tR\x04tags\x1a\x16\n\x04Part\x12\x0e\n\x02id\x18\x01 \x01(\tR\x02idB\x07\n\x05_name\"@\n\x04Size\x12\x16\n\x06inches\x18\x01 \x01(\x05R\x06inches\x12 \n\x0b\x64\x65scription\x18\x02 \x01(\tR\x0b\x64\x65scription2\xb7\x03\n\x0bHaberdasher\x12\x41\n\x07MakeHat\x12\x18.connectrpc.example.Size\x1a\x17.connectrpc.example.Hat\"\x03\x90\x02\x01\x12H\n\x0fMakeFlexibleHat\x12\x18.connectrpc.example.Size\x1a\x17.connectrpc.example.Hat\"\x00(\x01\x12K\n\x0fMakeSimilarHats\x12\x18.connectrpc.example.Size\x1a\x17.connectrpc.example.Hat\"\x03\x90\x02\x01\x30\x01\x12J\n\x0fMakeVariousHats\x12\x18.connectrpc.example.Size\x1a\x17.connectrpc.example.Hat\"\x00(\x01\x30\x01\x12\x45\n\tListParts\x12\x16.google.protobuf.Empty\x1a\x1c.connectrpc.example.Hat.Part\"\x00\x30\x01\x12;\n\tDoNothing\x12\x16.google.protobuf.Empty\x1a\x16.google.protobuf.EmptyB\tZ\x07\x65xampleb\x06proto3')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -28,11 +28,11 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_HABERDASHER'].methods_by_name['MakeSimilarHats']._loaded_options = None
   _globals['_HABERDASHER'].methods_by_name['MakeSimilarHats']._serialized_options = b'\220\002\001'
   _globals['_HAT']._serialized_start=70
-  _globals['_HAT']._serialized_end=175
-  _globals['_HAT_PART']._serialized_start=144
-  _globals['_HAT_PART']._serialized_end=166
-  _globals['_SIZE']._serialized_start=177
-  _globals['_SIZE']._serialized_end=241
-  _globals['_HABERDASHER']._serialized_start=244
-  _globals['_HABERDASHER']._serialized_end=683
+  _globals['_HAT']._serialized_end=195
+  _globals['_HAT_PART']._serialized_start=164
+  _globals['_HAT_PART']._serialized_end=186
+  _globals['_SIZE']._serialized_start=197
+  _globals['_SIZE']._serialized_end=261
+  _globals['_HABERDASHER']._serialized_start=264
+  _globals['_HABERDASHER']._serialized_end=703
 # @@protoc_insertion_point(module_scope)

--- a/test/haberdasher_pb2.pyi
+++ b/test/haberdasher_pb2.pyi
@@ -1,12 +1,13 @@
 from google.protobuf import empty_pb2 as _empty_pb2
+from google.protobuf.internal import containers as _containers
 from google.protobuf import descriptor as _descriptor
 from google.protobuf import message as _message
-from typing import ClassVar as _ClassVar, Optional as _Optional
+from typing import ClassVar as _ClassVar, Iterable as _Iterable, Optional as _Optional
 
 DESCRIPTOR: _descriptor.FileDescriptor
 
 class Hat(_message.Message):
-    __slots__ = ("size", "color", "name")
+    __slots__ = ("size", "color", "name", "tags")
     class Part(_message.Message):
         __slots__ = ("id",)
         ID_FIELD_NUMBER: _ClassVar[int]
@@ -15,10 +16,12 @@ class Hat(_message.Message):
     SIZE_FIELD_NUMBER: _ClassVar[int]
     COLOR_FIELD_NUMBER: _ClassVar[int]
     NAME_FIELD_NUMBER: _ClassVar[int]
+    TAGS_FIELD_NUMBER: _ClassVar[int]
     size: int
     color: str
     name: str
-    def __init__(self, size: _Optional[int] = ..., color: _Optional[str] = ..., name: _Optional[str] = ...) -> None: ...
+    tags: _containers.RepeatedScalarFieldContainer[str]
+    def __init__(self, size: _Optional[int] = ..., color: _Optional[str] = ..., name: _Optional[str] = ..., tags: _Optional[_Iterable[str]] = ...) -> None: ...
 
 class Size(_message.Message):
     __slots__ = ("inches", "description")

--- a/test/proto/haberdasher.proto
+++ b/test/proto/haberdasher.proto
@@ -19,6 +19,9 @@ message Hat {
   // The name of a hat is it's type. Like, 'bowler', or something.
   optional string name = 3;
 
+  // Tags for the hat (e.g., 'summer', 'formal').
+  repeated string tags = 4;
+
   // A part within a Hat.
   message Part {
     // The ID of the part.

--- a/test/test_codec.py
+++ b/test/test_codec.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+
+from connectrpc import MarshalOptions, ProtoJSONCodec
+
+from .haberdasher_pb2 import Hat
+
+
+def test_default_codec_omits_empty_repeated() -> None:
+    """Default ProtoJSONCodec omits empty repeated fields from JSON."""
+    codec = ProtoJSONCodec()
+    hat = Hat(size=1, color="red")
+    body = json.loads(codec.encode(hat))
+    assert "tags" not in body
+
+
+def test_always_print_fields_with_no_presence() -> None:
+    """ProtoJSONCodec with always_print_fields_with_no_presence includes empty repeated."""
+    options: MarshalOptions = {"always_print_fields_with_no_presence": True}
+    codec = ProtoJSONCodec(marshal_options=options)
+    hat = Hat(size=1, color="red")
+    body = json.loads(codec.encode(hat))
+    assert "tags" in body
+    assert body["tags"] == []
+
+
+def test_preserving_proto_field_name() -> None:
+    """ProtoJSONCodec with preserving_proto_field_name keeps snake_case keys."""
+    codec = ProtoJSONCodec(marshal_options={"preserving_proto_field_name": True})
+    hat = Hat(size=1, color="red")
+    body = json.loads(codec.encode(hat))
+    # Proto field names are already snake_case here, so just verify it works
+    assert body["size"] == 1
+    assert body["color"] == "red"
+
+
+def test_decode_roundtrip() -> None:
+    """Encode then decode preserves the message."""
+    codec = ProtoJSONCodec(
+        marshal_options={"always_print_fields_with_no_presence": True}
+    )
+    original = Hat(size=5, color="blue", tags=["summer", "formal"])
+    data = codec.encode(original)
+    decoded = codec.decode(data, Hat())
+    assert decoded.size == 5
+    assert decoded.color == "blue"
+    assert list(decoded.tags) == ["summer", "formal"]

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import io
+import json
 import struct
 from typing import TYPE_CHECKING
 
@@ -8,6 +10,7 @@ import pytest
 from pyqwest import Client, SyncClient
 from pyqwest.testing import ASGITransport, WSGITransport
 
+from connectrpc import ProtoJSONCodec
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 
@@ -357,3 +360,221 @@ async def test_server_stream_client_disconnect() -> None:
     assert generator_closed.is_set(), (
         "generator should be closed after client disconnect"
     )
+
+
+_json_codec = ProtoJSONCodec(
+    marshal_options={"always_print_fields_with_no_presence": True}
+)
+
+
+def test_json_codec_server_sync() -> None:
+    """WSGI server with custom json_codec includes empty repeated in JSON wire body."""
+
+    class SyncHaberdasher(HaberdasherSync):
+        def make_hat(self, request, ctx):
+            return Hat(size=request.inches, color="green")
+
+    app = HaberdasherWSGIApplication(SyncHaberdasher(), json_codec=_json_codec)
+    with HaberdasherClientSync(
+        "http://localhost",
+        http_client=SyncClient(WSGITransport(app=app)),
+        proto_json=True,
+        send_compression=None,
+        accept_compression=[],
+    ) as client:
+        response = client.make_hat(request=Size(inches=10))
+    assert response.size == 10
+    assert response.color == "green"
+
+
+def test_json_codec_server_sync_wire_body() -> None:
+    """Verify the wire JSON body from WSGI server contains empty repeated field."""
+
+    class SyncHaberdasher(HaberdasherSync):
+        def make_hat(self, request, ctx):
+            return Hat(size=request.inches, color="green")
+
+    app = HaberdasherWSGIApplication(SyncHaberdasher(), json_codec=_json_codec)
+    http_client = SyncClient(WSGITransport(app=app))
+    resp = http_client.post(
+        "http://localhost/connectrpc.example.Haberdasher/MakeHat",
+        content=b'{"inches": 10}',
+        headers={"content-type": "application/json"},
+    )
+    body = json.loads(resp.content)
+    assert "tags" in body
+    assert body["tags"] == []
+
+
+def test_json_codec_server_sync_proto_unaffected() -> None:
+    """Proto binary requests still work when json_codec is overridden on WSGI server."""
+
+    class SyncHaberdasher(HaberdasherSync):
+        def make_hat(self, request, ctx):
+            return Hat(size=request.inches, color="blue")
+
+    app = HaberdasherWSGIApplication(SyncHaberdasher(), json_codec=_json_codec)
+    with HaberdasherClientSync(
+        "http://localhost",
+        http_client=SyncClient(WSGITransport(app=app)),
+        proto_json=False,
+        send_compression=None,
+        accept_compression=[],
+    ) as client:
+        response = client.make_hat(request=Size(inches=5))
+    assert response.size == 5
+    assert response.color == "blue"
+
+
+@pytest.mark.asyncio
+async def test_json_codec_server_async() -> None:
+    """ASGI server with custom json_codec includes empty repeated in JSON wire body."""
+
+    class AsyncHaberdasher(Haberdasher):
+        async def make_hat(self, request, ctx):
+            return Hat(size=request.inches, color="green")
+
+    app = HaberdasherASGIApplication(AsyncHaberdasher(), json_codec=_json_codec)
+    transport = ASGITransport(app)
+    async with HaberdasherClient(
+        "http://localhost",
+        http_client=Client(transport),
+        proto_json=True,
+        send_compression=None,
+        accept_compression=[],
+    ) as client:
+        response = await client.make_hat(request=Size(inches=10))
+    assert response.size == 10
+    assert response.color == "green"
+
+
+@pytest.mark.asyncio
+async def test_json_codec_server_async_wire_body() -> None:
+    """Verify the wire JSON body from ASGI server contains empty repeated field."""
+
+    class AsyncHaberdasher(Haberdasher):
+        async def make_hat(self, request, ctx):
+            return Hat(size=request.inches, color="green")
+
+    app = HaberdasherASGIApplication(AsyncHaberdasher(), json_codec=_json_codec)
+    transport = ASGITransport(app)
+    http_client = Client(transport)
+    resp = await http_client.post(
+        "http://localhost/connectrpc.example.Haberdasher/MakeHat",
+        content=b'{"inches": 10}',
+        headers={"content-type": "application/json"},
+    )
+    body = json.loads(resp.content)
+    assert "tags" in body
+    assert body["tags"] == []
+
+
+@pytest.mark.asyncio
+async def test_json_codec_server_async_proto_unaffected() -> None:
+    """Proto binary requests still work when json_codec is overridden on ASGI server."""
+
+    class AsyncHaberdasher(Haberdasher):
+        async def make_hat(self, request, ctx):
+            return Hat(size=request.inches, color="blue")
+
+    app = HaberdasherASGIApplication(AsyncHaberdasher(), json_codec=_json_codec)
+    transport = ASGITransport(app)
+    async with HaberdasherClient(
+        "http://localhost",
+        http_client=Client(transport),
+        proto_json=False,
+        send_compression=None,
+        accept_compression=[],
+    ) as client:
+        response = await client.make_hat(request=Size(inches=5))
+    assert response.size == 5
+    assert response.color == "blue"
+
+
+def test_json_codec_client_sync() -> None:
+    """Sync client with custom json_codec encodes request with marshal options."""
+    captured_bodies: list[bytes] = []
+
+    class SyncHaberdasher(HaberdasherSync):
+        def make_hat(self, request, ctx):
+            return Hat(size=request.inches, color="green")
+
+    inner_app = HaberdasherWSGIApplication(SyncHaberdasher())
+
+    def capturing_app(environ, start_response):
+        body = environ["wsgi.input"].read()
+        captured_bodies.append(body)
+        environ["wsgi.input"] = io.BytesIO(body)
+        return inner_app(environ, start_response)
+
+    with HaberdasherClientSync(
+        "http://localhost",
+        http_client=SyncClient(WSGITransport(app=capturing_app)),
+        proto_json=True,
+        json_codec=_json_codec,
+        send_compression=None,
+        accept_compression=[],
+    ) as client:
+        client.make_hat(request=Size(inches=7))
+
+    assert len(captured_bodies) == 1
+    request_body = json.loads(captured_bodies[0])
+    # always_print_fields_with_no_presence causes the default-valued
+    # "description" field to appear in the wire JSON.
+    assert "description" in request_body
+    assert request_body["description"] == ""
+
+
+@pytest.mark.asyncio
+async def test_json_codec_client_async() -> None:
+    """Async client with custom json_codec encodes request with marshal options."""
+    captured_bodies: list[bytes] = []
+
+    class AsyncHaberdasher(Haberdasher):
+        async def make_hat(self, request, ctx):
+            return Hat(size=request.inches, color="green")
+
+    inner_app = HaberdasherASGIApplication(AsyncHaberdasher())
+
+    async def capturing_app(scope, receive, send):
+        if scope["type"] == "http":
+            original_receive = receive
+
+            async def capturing_receive():
+                message = await original_receive()
+                body = message.get("body", b"")
+                if message.get("type") == "http.request" and body:
+                    captured_bodies.append(body)
+                return message
+
+            await inner_app(scope, capturing_receive, send)
+        else:
+            await inner_app(scope, receive, send)
+
+    async with HaberdasherClient(
+        "http://localhost",
+        http_client=Client(ASGITransport(capturing_app)),
+        proto_json=True,
+        json_codec=_json_codec,
+        send_compression=None,
+        accept_compression=[],
+    ) as client:
+        await client.make_hat(request=Size(inches=7))
+
+    assert len(captured_bodies) == 1
+    request_body = json.loads(captured_bodies[0])
+    assert "description" in request_body
+    assert request_body["description"] == ""
+
+
+def test_json_codec_client_requires_proto_json_sync() -> None:
+    """Sync client raises ValueError if json_codec is set without proto_json=True."""
+    with pytest.raises(ValueError, match="json_codec requires proto_json=True"):
+        HaberdasherClientSync("http://localhost", json_codec=_json_codec)
+
+
+@pytest.mark.asyncio
+async def test_json_codec_client_requires_proto_json_async() -> None:
+    """Async client raises ValueError if json_codec is set without proto_json=True."""
+    with pytest.raises(ValueError, match="json_codec requires proto_json=True"):
+        HaberdasherClient("http://localhost", json_codec=_json_codec)


### PR DESCRIPTION
## Summary

- Add `MarshalOptions` TypedDict and parameterize
`ProtoJSONCodec.__init__` with `marshal_options`
- Add `json_codec` parameter to `ConnectASGIApplication`,
`ConnectWSGIApplication`, `ConnectClient`, and `ConnectClientSync`
- Server uses internal codec override map; client validates
`json_codec` requires `proto_json=True`
- Update codegen template to pass `json_codec` through generated
server constructors
- Export `ProtoJSONCodec` and `MarshalOptions` from
`connectrpc.__init__`
- Regenerate all proto stubs (test, example, conformance)

Closes connectrpc/connect-python#189

## Test plan

- [x] Unit tests: `ProtoJSONCodec` with
`always_print_fields_with_no_presence`,
`preserving_proto_field_name`, decode roundtrip
- [x] Integration tests: ASGI/WSGI server JSON wire body
verification (`"tags": []` present)
- [x] Integration tests: proto binary requests unaffected by
`json_codec` override
- [x] Integration tests: client request encoding verified via raw
body capture (WSGI middleware / ASGI receive wrapper)
- [x] Client `ValueError` when `json_codec` set without
`proto_json=True`
- [x] Generated code exposes `json_codec` parameter on server
constructors
- [x] Conformance suite: 7/7 passed
- [x] Full test suite: 191/191 passed