### PR TITLE
Link to API docs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![CI](https://github.com/connectrpc/connect-python/actions/workflows/ci.yaml/badge.svg)](https://github.com/connectrpc/connect-python/actions/workflows/ci.yaml)
 [![codecov](https://codecov.io/github/connectrpc/connect-python/graph/badge.svg)](https://codecov.io/github/connectrpc/connect-python)
 [![PyPI version](https://img.shields.io/pypi/v/connect-python)](https://pypi.org/project/connect-python)
+[![API Docs](https://img.shields.io/badge/API_Docs-connectrpc.github.io-blue)](https://connectrpc.github.io/connect-python/api/)
 
 A Python implementation of [Connect](https://connectrpc.com/): Protobuf RPC that works.
 


### PR DESCRIPTION
We publish these at https://connectrpc.github.io/connect-python/, but I had trouble finding that URL anywhere. This just adds a badge with a link to them at the top of the README, which seems common for Python projects.