### PR TITLE
Add .github/release.yaml and update RELEASE.md instructions

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -1,0 +1,6 @@
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+    authors:
+      - renovate[bot]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,18 +7,18 @@ This document outlines how to create a release of connect-python.
 2. On a new branch, update version strings with the `bump` command, either to the next minor or patch version, based on the changes that are included in this new release.
 
 - If there are only bug fixes and no new features, run `uv run poe bump --version patch`.
-- If there are features being released, run `uv run poe bump --version minor`.
+- If there are features being released (or breaking changes being made while we're pre-1.0 release), run `uv run poe bump --version minor`.
 
 Note the new version X.Y.Z in the updated files.
 
-3. Open a PR titled "Prepare for vX.Y.Z" ([Example PR #60](https://github.com/connectrpc/connect-python/pull/60)) and assign the `connectrpc/python` group as reviewers. Once it's approved by at
+3. Open a PR titled "Prepare for vX.Y.Z" ([Example PR: #60](https://github.com/connectrpc/connect-python/pull/60)) and assign the `connectrpc/python` group as reviewers. Once it's approved by at
    least one other maintainer and CI passes, merge it.
 
    _Make sure no new commits are merged until the release is complete._
 
 4. Review all commits in the new release and for each PR check an appropriate label is used and edit the title to be meaningful to end users.
 
-5. Using the Github UI, create a new release.
+5. Using the GitHub UI, create a new release.
 
    - Under “Select tag”, type in “vX.Y.Z” to create a new tag for the release upon publish.
    - Target the main branch.
@@ -26,8 +26,6 @@ Note the new version X.Y.Z in the updated files.
    - Click “set as latest release”.
    - Set the last version as the “Previous tag”.
    - Click “Generate release notes” to autogenerate release notes.
-   - Edit the release notes. A summary and other categories should be added, in most cases, with the two categories ### Enhancements and ### Bugfixes. Feel free to collect multiple small changes to docs or Github config into one line, but try to tag every contributor. Make especially sure to credit new external contributors!
+   - Edit the release notes. A summary and other categories should be added, in most cases, with the two categories ### Enhancements and ### Bugfixes. Feel free to collect multiple small changes to docs or GitHub config into one line, but try to tag every contributor. Make especially sure to credit new external contributors!
 
 6. Publish the release.
-
-[latest release]: https://github.com/connectrpc/connect-python/releases/latest


### PR DESCRIPTION
Noticed we had a lot of Renovate/Dependabot PRs included in the autogenerated release notes, and also thought I'd clarify further the bump we ought to make for breaking changes (we ought to revisit after 1.0).