### PR TITLE
Prepare for v0.10.0

### DIFF
--- a/protoc-gen-connect-python/pyproject.toml
+++ b/protoc-gen-connect-python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoc-gen-connectrpc"
-version = "0.9.1"
+version = "0.10.0"
 description = "Code generator for connect-python"
 readme = "README.md"
 requires-python = ">= 3.10"

--- a/protoc-gen-connect-python/uv.lock
+++ b/protoc-gen-connect-python/uv.lock
@@ -13,7 +13,7 @@ wheels = [
 
 [[package]]
 name = "protoc-gen-connectrpc"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 
 [package.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "connectrpc"
-version = "0.9.1"
+version = "0.10.0"
 description = "Server and client runtime library for Connect RPC"
 readme = "README.md"
 requires-python = ">= 3.10"

--- a/uv.lock
+++ b/uv.lock
@@ -381,7 +381,7 @@ requires-dist = [
 
 [[package]]
 name = "connectrpc"
-version = "0.9.1"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "protobuf" },


### PR DESCRIPTION
Based on [this comment][1], I think our next release ought to be `v0.10.0`.

[1]: https://github.com/connectrpc/connect-python/pull/230#issuecomment-4336155130