### PR TITLE
Disambiguate release workflow names

### DIFF
--- a/.github/workflows/release-otel.yaml
+++ b/.github/workflows/release-otel.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Release connectrpc-otel
 on:
   push:
     tags:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,4 +1,4 @@
-name: Release
+name: Release connectrpc
 on:
   push:
     tags:


### PR DESCRIPTION
Noticed this in the actions UI; felt like we ought to split these out.