### PR TITLE
Update unary-get query parameter to match spec ordering

### DIFF
--- a/src/connectrpc/_client_shared.py
+++ b/src/connectrpc/_client_shared.py
@@ -22,14 +22,14 @@ RES = TypeVar("RES")
 def prepare_get_params(
     codec: Codec, request_data: bytes, headers: HTTPHeaders
 ) -> dict[str, str]:
-    params = {
-        "connect": f"v{CONNECT_PROTOCOL_VERSION}",
-        "message": base64.urlsafe_b64encode(request_data).decode("ascii"),
-        "base64": "1",
-        "encoding": codec.name(),
-    }
+    # Insertion order is the Query-Get order from the Connect spec; urlencode
+    # iterates dict items in insertion order, which has been guaranteed since
+    # Python 3.7 (we require >= 3.10).
+    params: dict[str, str] = {"connect": f"v{CONNECT_PROTOCOL_VERSION}", "base64": "1"}
     if "content-encoding" in headers:
         params["compression"] = headers.pop("content-encoding")
+    params["encoding"] = codec.name()
+    params["message"] = base64.urlsafe_b64encode(request_data).decode("ascii")
     return params
 
 

--- a/src/connectrpc/_client_shared.py
+++ b/src/connectrpc/_client_shared.py
@@ -22,9 +22,7 @@ RES = TypeVar("RES")
 def prepare_get_params(
     codec: Codec, request_data: bytes, headers: HTTPHeaders
 ) -> dict[str, str]:
-    # Insertion order is the Query-Get order from the Connect spec; urlencode
-    # iterates dict items in insertion order, which has been guaranteed since
-    # Python 3.7 (we require >= 3.10).
+    # Follow order in spec: https://connectrpc.com/docs/protocol/#unary-get-request
     params: dict[str, str] = {"connect": f"v{CONNECT_PROTOCOL_VERSION}", "base64": "1"}
     if "content-encoding" in headers:
         params["compression"] = headers.pop("content-encoding")

--- a/test/test_client_shared.py
+++ b/test/test_client_shared.py
@@ -8,12 +8,7 @@ from connectrpc._client_shared import prepare_get_params
 from connectrpc.codec import proto_binary_codec
 
 
-def test_prepare_get_params_order_without_compression() -> None:
-    params = prepare_get_params(proto_binary_codec(), b"hello", HTTPHeaders([]))
-    assert list(params.keys()) == ["connect", "base64", "encoding", "message"]
-
-
-def test_prepare_get_params_order_with_compression() -> None:
+def test_prepare_get_params_order() -> None:
     headers = HTTPHeaders([("content-encoding", "gzip")])
     params = prepare_get_params(proto_binary_codec(), b"hello", headers)
     assert list(params.keys()) == [
@@ -24,11 +19,11 @@ def test_prepare_get_params_order_with_compression() -> None:
         "message",
     ]
     assert "content-encoding" not in headers
-
-
-def test_prepare_get_params_urlencode_order() -> None:
-    headers = HTTPHeaders([("content-encoding", "gzip")])
-    params = prepare_get_params(proto_binary_codec(), b"hello", headers)
     query = urlencode(params)
     expected_prefix = "connect=v1&base64=1&compression=gzip&encoding=proto&message="
     assert query.startswith(expected_prefix)
+
+
+def test_prepare_get_params_order_without_compression() -> None:
+    params = prepare_get_params(proto_binary_codec(), b"hello", HTTPHeaders([]))
+    assert list(params.keys()) == ["connect", "base64", "encoding", "message"]

--- a/test/test_client_shared.py
+++ b/test/test_client_shared.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from pyqwest import Headers as HTTPHeaders
+
+from connectrpc._client_shared import prepare_get_params
+from connectrpc.codec import proto_binary_codec
+
+
+def test_prepare_get_params_order_without_compression() -> None:
+    params = prepare_get_params(proto_binary_codec(), b"hello", HTTPHeaders([]))
+    assert list(params.keys()) == ["connect", "base64", "encoding", "message"]
+
+
+def test_prepare_get_params_order_with_compression() -> None:
+    headers = HTTPHeaders([("content-encoding", "gzip")])
+    params = prepare_get_params(proto_binary_codec(), b"hello", headers)
+    assert list(params.keys()) == [
+        "connect",
+        "base64",
+        "compression",
+        "encoding",
+        "message",
+    ]
+    assert "content-encoding" not in headers
+
+
+def test_prepare_get_params_urlencode_order() -> None:
+    headers = HTTPHeaders([("content-encoding", "gzip")])
+    params = prepare_get_params(proto_binary_codec(), b"hello", headers)
+    query = urlencode(params)
+    expected_prefix = "connect=v1&base64=1&compression=gzip&encoding=proto&message="
+    assert query.startswith(expected_prefix)


### PR DESCRIPTION
This is a follow-up to  https://github.com/connectrpc/connectrpc.com/pull/357