### PR TITLE
Manage pytest as normal dependencies

### DIFF
--- a/connectrpc-otel/pyproject.toml
+++ b/connectrpc-otel/pyproject.toml
@@ -64,7 +64,7 @@ dev = [
   "connectrpc>=0.11.0",
 
   "connect-python-example",
-  "pytest",
+  "pytest==9.1.0",
 ]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -243,11 +243,6 @@ exclude = [
 # subprocesses put `conformance/test/` on sys.path; teach ty to do the same.
 extra-paths = ["conformance/test"]
 
-[tool.uv]
-constraint-dependencies = [
-  "coverage==7.13.2",
-]
-
 [tool.uv.build-backend]
 module-name = "connectrpc"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,10 @@ dev = [
   "gunicorn==26.0.0",
   "hypercorn==0.18.0",
   "poethepoet==0.46.0",
+  "pytest==9.1.0",
+  "pytest-asyncio==1.4.0",
+  "pytest-cov==7.1.0",
+  "pytest-timeout==2.4.0",
   "pyvoy==0.3.0",
   "ruff==0.15.17",
   "tombi==1.1.3",
@@ -67,12 +71,6 @@ dev = [
   "opentelemetry-instrumentation-asgi==0.63b1",
   "opentelemetry-instrumentation-wsgi==0.63b1",
   "opentelemetry-sdk==1.42.1",
-
-  # Versions locked in constraint-dependencies
-  "pytest",
-  "pytest-asyncio",
-  "pytest-cov",
-  "pytest-timeout",
 ]
 
 docs = ["mkdocstrings-python==2.0.4", "zensical==0.0.45"]
@@ -248,10 +246,6 @@ extra-paths = ["conformance/test"]
 [tool.uv]
 constraint-dependencies = [
   "coverage==7.13.2",
-  "pytest==9.0.2",
-  "pytest-asyncio==1.3.0",
-  "pytest-cov==7.0.0",
-  "pytest-timeout==2.4.0",
 ]
 
 [tool.uv.build-backend]

--- a/renovate.json
+++ b/renovate.json
@@ -17,7 +17,7 @@
         "project.dependencies",
         "project.optional-dependencies"
       ],
-      "matchFileNames": ["**/pyproject.toml"],
+      "matchFileNames": ["pyproject.toml", "connectrpc-otel/pyproject.toml"],
       // We manage production dependencies ourselves, only bumping
       // when necessary.
       "enabled": false

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,6 @@ members = [
     "connectrpc",
     "connectrpc-otel",
 ]
-constraints = [{ name = "coverage", specifier = "==7.13.2" }]
 
 [[package]]
 name = "anyio"

--- a/uv.lock
+++ b/uv.lock
@@ -8,13 +8,7 @@ members = [
     "connectrpc",
     "connectrpc-otel",
 ]
-constraints = [
-    { name = "coverage", specifier = "==7.13.2" },
-    { name = "pytest", specifier = "==9.0.2" },
-    { name = "pytest-asyncio", specifier = "==1.3.0" },
-    { name = "pytest-cov", specifier = "==7.0.0" },
-    { name = "pytest-timeout", specifier = "==2.4.0" },
-]
+constraints = [{ name = "coverage", specifier = "==7.13.2" }]
 
 [[package]]
 name = "anyio"
@@ -237,10 +231,10 @@ dev = [
     { name = "opentelemetry-instrumentation-wsgi", specifier = "==0.63b1" },
     { name = "opentelemetry-sdk", specifier = "==1.42.1" },
     { name = "poethepoet", specifier = "==0.46.0" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "pytest-cov" },
-    { name = "pytest-timeout" },
+    { name = "pytest", specifier = "==9.1.0" },
+    { name = "pytest-asyncio", specifier = "==1.4.0" },
+    { name = "pytest-cov", specifier = "==7.1.0" },
+    { name = "pytest-timeout", specifier = "==2.4.0" },
     { name = "pyvoy", specifier = "==0.3.0" },
     { name = "ruff", specifier = "==0.15.17" },
     { name = "tombi", specifier = "==1.1.3" },
@@ -282,7 +276,7 @@ requires-dist = [
 dev = [
     { name = "connect-python-example", editable = "example" },
     { name = "connectrpc", editable = "." },
-    { name = "pytest" },
+    { name = "pytest", specifier = "==9.1.0" },
 ]
 
 [[package]]
@@ -1226,7 +1220,7 @@ wheels = [
 
 [[package]]
 name = "pytest"
-version = "9.0.2"
+version = "9.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
@@ -1237,37 +1231,37 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/0e/b5858858d74958632c49b72cb25a3976ff9f632397626715be71c89d3971/pytest-9.1.0.tar.gz", hash = "sha256:41dd9148c08072446394cefd3d79701701335a9f4cae69ba92e39f6c7f5c061c", size = 1634181, upload-time = "2026-06-13T18:52:45.983Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/5a/ba30a81239b909821b3153e303e7def45178bf353da4f72380e6c5e8793b/pytest-9.1.0-py3-none-any.whl", hash = "sha256:8ebb0e7888bdf2bdfc602ec51f8f62d50200af37356c74e503c79a94f5c81f32", size = 386453, upload-time = "2026-06-13T18:52:44.045Z" },
 ]
 
 [[package]]
 name = "pytest-asyncio"
-version = "1.3.0"
+version = "1.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]
 name = "pytest-cov"
-version = "7.0.0"
+version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "coverage", extra = ["toml"] },
     { name = "pluggy" },
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Not sure but I think we moved these to constraint dependencies to reduce dependabot issues - with renovate, all pytest versions should get bumped together and not have any issue. On the flip side, renovate can't bump constraint-dependencies, so we end up with not getting updates to these.

Also scoped the "don't bump project.dependencies" to the two published Python packages, so that example can be bumped (for starlette).