### PR TITLE
Only publish packages in release workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,7 +102,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
-  publish:
+  wheels:
     runs-on: ubuntu-24.04
     needs: ci
     steps:
@@ -116,16 +116,12 @@ jobs:
 
       - run: uv build
 
-      # Builds to root dist directory so published together with the main project.
-      - run: uv build
-        working-directory: connectrpc-otel
-
       - name: build codegen archives
         run: uv build
         working-directory: protoc-gen-connectrpc
 
-      - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
-        if: github.event_name != 'pull_request'
-        with:
-          repository-url: https://test.pypi.org/legacy/
-          skip-existing: true
+      - run: uv build
+        working-directory: connectrpc-otel
+
+      - run: uv build
+        working-directory: connectrpc-grpcreflect

--- a/.github/workflows/release-grpcreflect.yaml
+++ b/.github/workflows/release-grpcreflect.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-24.04
-    environment: pypi-release
+    environment: ${{ (github.event_name == 'workflow_dispatch' && 'pypi-test') || (github.event_name == 'push' && github.ref_type == 'tag' && 'pypi-release') || null }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -28,4 +28,5 @@ jobs:
       - name: publish connectrpc-grpcreflect
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
+          repository-url: ${{ github.event_name == 'workflow_dispatch' && 'https://test.pypi.org/legacy/' || null }}
           skip-existing: true

--- a/.github/workflows/release-otel.yaml
+++ b/.github/workflows/release-otel.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-24.04
-    environment: pypi-release
+    environment: ${{ (github.event_name == 'workflow_dispatch' && 'pypi-test') || (github.event_name == 'push' && github.ref_type == 'tag' && 'pypi-release') || null }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -28,4 +28,5 @@ jobs:
       - name: publish connectrpc-otel
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
+          repository-url: ${{ github.event_name == 'workflow_dispatch' && 'https://test.pypi.org/legacy/' || null }}
           skip-existing: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-24.04
-    environment: pypi-release
+    environment: ${{ (github.event_name == 'workflow_dispatch' && 'pypi-test') || (github.event_name == 'push' && github.ref_type == 'tag' && 'pypi-release') || null }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -30,4 +30,5 @@ jobs:
       - name: publish
         uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
         with:
+          repository-url: ${{ github.event_name == 'workflow_dispatch' && 'https://test.pypi.org/legacy/' || null }}
           skip-existing: true


### PR DESCRIPTION
It was always a bit suspicious having a no-op push on main merge to test the release build, but recently got "cannot upload to release more than 14 days old". Not sure if this is a new check but anyways we have enough wheels to be better. Now, testing release workflows is opt-in with workflow_dispatch on the actual release workflows and we only build wheels on CI to verify building.