### PR TITLE
Fix connect logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-![The Connect logo](https://raw.githubusercontent.com/connectrpc/connectrpc.com/12f7ad8e95c5f784700bc280708b27cd148d0cf1/public/img/logo.svg)
+![The Connect logo](https://raw.githubusercontent.com/connectrpc/connectrpc.com/12f7ad8e95c5f784700bc280708b27cd148d0cf1/public/img/logos/simple-connect.svg)
 
 # Connect for Python
 


### PR DESCRIPTION
Eyes glossed over the actual logo image until now, `logo.svg` seems to be an unused placeholder that is the Buf logo, not Connect logo.