### PR TITLE
Expose HTTP status code in ResponseMetadata

### DIFF
--- a/src/connectrpc/_client_async.py
+++ b/src/connectrpc/_client_async.py
@@ -327,6 +327,7 @@ class ConnectClient:
                     ),
                     timeout_s,
                 )
+            handle_response_headers(resp.status, resp.headers)
 
             self._protocol.validate_response(
                 self._codec.name(), resp.status, resp.headers.get("content-type", "")
@@ -336,7 +337,6 @@ class ConnectClient:
             self._protocol.handle_response_compression(
                 resp.headers, self._response_compressions, stream=False
             )
-            handle_response_headers(resp.status, resp.headers)
 
             if resp.status == 200:
                 if (

--- a/src/connectrpc/_client_async.py
+++ b/src/connectrpc/_client_async.py
@@ -336,7 +336,7 @@ class ConnectClient:
             self._protocol.handle_response_compression(
                 resp.headers, self._response_compressions, stream=False
             )
-            handle_response_headers(resp.headers)
+            handle_response_headers(resp.status, resp.headers)
 
             if resp.status == 200:
                 if (
@@ -394,7 +394,7 @@ class ConnectClient:
                     "POST", url, headers=request_headers, content=request_data
                 ) as resp,
             ):
-                handle_response_headers(resp.headers)
+                handle_response_headers(resp.status, resp.headers)
                 if resp.status == 200:
                     self._protocol.validate_stream_response(
                         self._codec.name(), resp.headers.get("content-type", "")

--- a/src/connectrpc/_client_sync.py
+++ b/src/connectrpc/_client_sync.py
@@ -333,7 +333,7 @@ class ConnectClientSync:
             self._protocol.handle_response_compression(
                 resp.headers, self._response_compressions, stream=False
             )
-            handle_response_headers(resp.headers)
+            handle_response_headers(resp.status, resp.headers)
 
             if resp.status == 200:
                 if (
@@ -389,7 +389,7 @@ class ConnectClientSync:
                 content=request_data,
                 timeout=timeout_s,
             ) as resp:
-                handle_response_headers(resp.headers)
+                handle_response_headers(resp.status, resp.headers)
 
                 if resp.status == 200:
                     self._protocol.validate_stream_response(

--- a/src/connectrpc/_client_sync.py
+++ b/src/connectrpc/_client_sync.py
@@ -324,6 +324,7 @@ class ConnectClientSync:
                     content=request_data,
                     timeout=timeout_s,
                 )
+            handle_response_headers(resp.status, resp.headers)
 
             self._protocol.validate_response(
                 self._codec.name(), resp.status, resp.headers.get("content-type", "")
@@ -333,7 +334,6 @@ class ConnectClientSync:
             self._protocol.handle_response_compression(
                 resp.headers, self._response_compressions, stream=False
             )
-            handle_response_headers(resp.status, resp.headers)
 
             if resp.status == 200:
                 if (

--- a/src/connectrpc/_response_metadata.py
+++ b/src/connectrpc/_response_metadata.py
@@ -16,11 +16,12 @@ if TYPE_CHECKING:
 _current_response = ContextVar["ResponseMetadata"]("connectrpc_current_response")
 
 
-def handle_response_headers(headers: HTTPHeaders) -> None:
+def handle_response_headers(status: int, headers: HTTPHeaders) -> None:
     response = _current_response.get(None)
     if not response:
         return
 
+    response._http_status = status  # noqa: SLF001
     response_headers: Headers = Headers()
     response_trailers: Headers = Headers()
     for key, value in headers.items():
@@ -60,8 +61,8 @@ class ResponseMetadata:
 
     Commonly, RPC client invocations only need the message payload and do not need to
     directly read other data such as headers or trailers. In cases where they are needed,
-    initialize this class in a context manager to access the response headers and trailers
-    for the invocation made within the context.
+    initialize this class in a context manager to access the response HTTP status,
+    headers and trailers for the invocation made within the context.
 
     Example:
         ```python
@@ -73,6 +74,7 @@ class ResponseMetadata:
         ```
     """
 
+    _http_status: int | None = None
     _headers: Headers | None = None
     _trailers: Headers | None = None
     _token: Token[ResponseMetadata] | None = None
@@ -94,6 +96,13 @@ class ResponseMetadata:
             with contextlib.suppress(Exception):
                 _current_response.reset(self._token)
         self._token = None
+
+    @property
+    def http_status(self) -> int:
+        """Returns the HTTP status code of the response."""
+        if self._http_status is None:
+            return 0
+        return self._http_status
 
     @property
     def headers(self) -> Headers:

--- a/src/connectrpc/_response_metadata.py
+++ b/src/connectrpc/_response_metadata.py
@@ -98,10 +98,12 @@ class ResponseMetadata:
         self._token = None
 
     @property
-    def http_status(self) -> int:
-        """Returns the HTTP status code of the response."""
-        if self._http_status is None:
-            return 0
+    def http_status(self) -> int | None:
+        """Returns the HTTP status code of the response.
+
+        If an HTTP response wasn't received, for example due to a network error,
+        this will return `None`.
+        """
         return self._http_status
 
     @property

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -73,7 +73,7 @@ def test_headers_sync(headers, trailers, response_headers, response_trailers) ->
     )
 
     with ResponseMetadata() as resp:
-        assert resp.http_status == 0
+        assert resp.http_status is None
         assert list(resp.headers.allitems()) == []
         assert list(resp.trailers.allitems()) == []
         client.make_hat(Size(inches=10))
@@ -113,7 +113,7 @@ async def test_headers_async(
     )
 
     with ResponseMetadata() as resp:
-        assert resp.http_status == 0
+        assert resp.http_status is None
         assert list(resp.headers.allitems()) == []
         assert list(resp.trailers.allitems()) == []
         await client.make_hat(Size(inches=10))

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -73,8 +73,12 @@ def test_headers_sync(headers, trailers, response_headers, response_trailers) ->
     )
 
     with ResponseMetadata() as resp:
+        assert resp.http_status == 0
+        assert list(resp.headers.allitems()) == []
+        assert list(resp.trailers.allitems()) == []
         client.make_hat(Size(inches=10))
 
+    assert resp.http_status == 200
     assert list(resp.headers.allitems()) == response_headers
     assert list(resp.trailers.allitems()) == response_trailers
 
@@ -109,7 +113,11 @@ async def test_headers_async(
     )
 
     with ResponseMetadata() as resp:
+        assert resp.http_status == 0
+        assert list(resp.headers.allitems()) == []
+        assert list(resp.trailers.allitems()) == []
         await client.make_hat(Size(inches=10))
 
+    assert resp.http_status == 200
     assert list(resp.headers.allitems()) == response_headers
     assert list(resp.trailers.allitems()) == response_trailers

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -203,10 +203,13 @@ def test_sync_http_errors(
             "http://localhost", http_client=SyncClient(transport=MockTransport())
         ) as client,
         pytest.raises(ConnectError) as exc_info,
+        ResponseMetadata() as resp,
     ):
         client.make_hat(request=Size(inches=10))
     assert exc_info.value.code == code
     assert exc_info.value.message == message
+    assert resp.http_status == response_status
+    assert resp.headers == response_headers
 
 
 @pytest.mark.asyncio
@@ -227,10 +230,12 @@ async def test_async_http_errors(
     async with HaberdasherClient(
         "http://localhost", http_client=Client(transport=MockTransport())
     ) as client:
-        with pytest.raises(ConnectError) as exc_info:
+        with pytest.raises(ConnectError) as exc_info, ResponseMetadata() as resp:
             await client.make_hat(request=Size(inches=10))
     assert exc_info.value.code == code
     assert exc_info.value.message == message
+    assert resp.http_status == response_status
+    assert resp.headers == response_headers
 
 
 _client_errors = [

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -20,6 +20,7 @@ from pyqwest import (
 from pyqwest.testing import ASGITransport, WSGITransport
 
 from connectrpc._protocol import HTTPException
+from connectrpc.client import ResponseMetadata
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
 
@@ -86,6 +87,7 @@ def test_sync_errors(code: Code, message: str, http_status: int) -> None:
     with (
         HaberdasherClientSync("http://localhost", http_client=http_client) as client,
         pytest.raises(ConnectError) as exc_info,
+        ResponseMetadata() as resp,
     ):
         client.make_hat(request=Size(inches=10))
 
@@ -93,6 +95,7 @@ def test_sync_errors(code: Code, message: str, http_status: int) -> None:
     assert exc_info.value.message == message
     assert recorded_response is not None
     assert recorded_response.status == http_status
+    assert resp.http_status == http_status
 
 
 @pytest.mark.asyncio
@@ -123,13 +126,14 @@ async def test_async_errors(code: Code, message: str, http_status: int) -> None:
 
     http_client = Client(transport=ResponseRecorder(transport))
     async with HaberdasherClient("http://localhost", http_client=http_client) as client:
-        with pytest.raises(ConnectError) as exc_info:
+        with pytest.raises(ConnectError) as exc_info, ResponseMetadata() as resp:
             await client.make_hat(request=Size(inches=10))
 
     assert exc_info.value.code == code
     assert exc_info.value.message == message
     assert recorded_response is not None
     assert recorded_response.status == http_status
+    assert resp.http_status == http_status
 
 
 _http_errors = [


### PR DESCRIPTION
HTTP status is quite similar to headers and trailers in we expect it to mostly be used in HTTP middleware rather than the business logic using connect, but sometimes it may be needed and `ResponseMetadata` is our mechanism for it.

Fixes #306 