### PR TITLE
Use positional-only parameters for implemented protocols

### DIFF
--- a/conformance/test/gen/connectrpc/conformance/v1/service_connect.py
+++ b/conformance/test/gen/connectrpc/conformance/v1/service_connect.py
@@ -35,7 +35,7 @@ class ConformanceService(Protocol):
 
     Test servers must implement the service as described.
     """
-    async def unary(self, request: UnaryRequest, ctx: RequestContext[UnaryRequest, UnaryResponse]) -> UnaryResponse:
+    async def unary(self, request: UnaryRequest, ctx: RequestContext[UnaryRequest, UnaryResponse], /) -> UnaryResponse:
         """
         A unary operation. The request indicates the response headers and trailers
         and also indicates either a response message or an error to send back.
@@ -54,7 +54,7 @@ class ConformanceService(Protocol):
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def server_stream(self, request: ServerStreamRequest, ctx: RequestContext[ServerStreamRequest, ServerStreamResponse]) -> AsyncIterator[ServerStreamResponse]:
+    def server_stream(self, request: ServerStreamRequest, ctx: RequestContext[ServerStreamRequest, ServerStreamResponse], /) -> AsyncIterator[ServerStreamResponse]:
         """
         A server-streaming operation. The request indicates the response headers,
         response messages, trailers, and an optional error to send back. The
@@ -79,7 +79,7 @@ class ConformanceService(Protocol):
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    async def client_stream(self, request: AsyncIterator[ClientStreamRequest], ctx: RequestContext[ClientStreamRequest, ClientStreamResponse]) -> ClientStreamResponse:
+    async def client_stream(self, request: AsyncIterator[ClientStreamRequest], ctx: RequestContext[ClientStreamRequest, ClientStreamResponse], /) -> ClientStreamResponse:
         """
         A client-streaming operation. The first request indicates the response
         headers and trailers and also indicates either a response message or an
@@ -102,7 +102,7 @@ class ConformanceService(Protocol):
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def bidi_stream(self, request: AsyncIterator[BidiStreamRequest], ctx: RequestContext[BidiStreamRequest, BidiStreamResponse]) -> AsyncIterator[BidiStreamResponse]:
+    def bidi_stream(self, request: AsyncIterator[BidiStreamRequest], ctx: RequestContext[BidiStreamRequest, BidiStreamResponse], /) -> AsyncIterator[BidiStreamResponse]:
         """
         A bidirectional-streaming operation. The first request indicates the response
         headers, response messages, trailers, and an optional error to send back.
@@ -155,14 +155,14 @@ class ConformanceService(Protocol):
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    async def unimplemented(self, request: UnimplementedRequest, ctx: RequestContext[UnimplementedRequest, UnimplementedResponse]) -> UnimplementedResponse:
+    async def unimplemented(self, request: UnimplementedRequest, ctx: RequestContext[UnimplementedRequest, UnimplementedResponse], /) -> UnimplementedResponse:
         """
         A unary endpoint that the server should not implement and should instead
         return an unimplemented error when invoked.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    async def idempotent_unary(self, request: IdempotentUnaryRequest, ctx: RequestContext[IdempotentUnaryRequest, IdempotentUnaryResponse]) -> IdempotentUnaryResponse:
+    async def idempotent_unary(self, request: IdempotentUnaryRequest, ctx: RequestContext[IdempotentUnaryRequest, IdempotentUnaryResponse], /) -> IdempotentUnaryResponse:
         """
         A unary endpoint denoted as having no side effects (i.e. idempotent).
         Implementations should use an HTTP GET when invoking this endpoint and
@@ -516,7 +516,7 @@ class ConformanceServiceSync(Protocol):
 
     Test servers must implement the service as described.
     """
-    def unary(self, request: UnaryRequest, ctx: RequestContext[UnaryRequest, UnaryResponse]) -> UnaryResponse:
+    def unary(self, request: UnaryRequest, ctx: RequestContext[UnaryRequest, UnaryResponse], /) -> UnaryResponse:
         """
         A unary operation. The request indicates the response headers and trailers
         and also indicates either a response message or an error to send back.
@@ -535,7 +535,7 @@ class ConformanceServiceSync(Protocol):
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def server_stream(self, request: ServerStreamRequest, ctx: RequestContext[ServerStreamRequest, ServerStreamResponse]) -> Iterator[ServerStreamResponse]:
+    def server_stream(self, request: ServerStreamRequest, ctx: RequestContext[ServerStreamRequest, ServerStreamResponse], /) -> Iterator[ServerStreamResponse]:
         """
         A server-streaming operation. The request indicates the response headers,
         response messages, trailers, and an optional error to send back. The
@@ -560,7 +560,7 @@ class ConformanceServiceSync(Protocol):
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def client_stream(self, request: Iterator[ClientStreamRequest], ctx: RequestContext[ClientStreamRequest, ClientStreamResponse]) -> ClientStreamResponse:
+    def client_stream(self, request: Iterator[ClientStreamRequest], ctx: RequestContext[ClientStreamRequest, ClientStreamResponse], /) -> ClientStreamResponse:
         """
         A client-streaming operation. The first request indicates the response
         headers and trailers and also indicates either a response message or an
@@ -583,7 +583,7 @@ class ConformanceServiceSync(Protocol):
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def bidi_stream(self, request: Iterator[BidiStreamRequest], ctx: RequestContext[BidiStreamRequest, BidiStreamResponse]) -> Iterator[BidiStreamResponse]:
+    def bidi_stream(self, request: Iterator[BidiStreamRequest], ctx: RequestContext[BidiStreamRequest, BidiStreamResponse], /) -> Iterator[BidiStreamResponse]:
         """
         A bidirectional-streaming operation. The first request indicates the response
         headers, response messages, trailers, and an optional error to send back.
@@ -636,14 +636,14 @@ class ConformanceServiceSync(Protocol):
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def unimplemented(self, request: UnimplementedRequest, ctx: RequestContext[UnimplementedRequest, UnimplementedResponse]) -> UnimplementedResponse:
+    def unimplemented(self, request: UnimplementedRequest, ctx: RequestContext[UnimplementedRequest, UnimplementedResponse], /) -> UnimplementedResponse:
         """
         A unary endpoint that the server should not implement and should instead
         return an unimplemented error when invoked.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def idempotent_unary(self, request: IdempotentUnaryRequest, ctx: RequestContext[IdempotentUnaryRequest, IdempotentUnaryResponse]) -> IdempotentUnaryResponse:
+    def idempotent_unary(self, request: IdempotentUnaryRequest, ctx: RequestContext[IdempotentUnaryRequest, IdempotentUnaryResponse], /) -> IdempotentUnaryResponse:
         """
         A unary endpoint denoted as having no side effects (i.e. idempotent).
         Implementations should use an HTTP GET when invoking this endpoint and

--- a/connectrpc-grpcreflect/connectrpc_grpcreflect/_gen/grpc/reflection/v1/reflection_connect.py
+++ b/connectrpc-grpcreflect/connectrpc_grpcreflect/_gen/grpc/reflection/v1/reflection_connect.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 class ServerReflection(Protocol):
-    def server_reflection_info(self, request: AsyncIterator[ServerReflectionRequest], ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse]) -> AsyncIterator[ServerReflectionResponse]:
+    def server_reflection_info(self, request: AsyncIterator[ServerReflectionRequest], ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse], /) -> AsyncIterator[ServerReflectionResponse]:
         """
         The reflection service is structured as a bidirectional stream, ensuring
         all related requests go to a single server.
@@ -102,7 +102,7 @@ class ServerReflectionClient(ConnectClient):
         )
 
 class ServerReflectionSync(Protocol):
-    def server_reflection_info(self, request: Iterator[ServerReflectionRequest], ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse]) -> Iterator[ServerReflectionResponse]:
+    def server_reflection_info(self, request: Iterator[ServerReflectionRequest], ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse], /) -> Iterator[ServerReflectionResponse]:
         """
         The reflection service is structured as a bidirectional stream, ensuring
         all related requests go to a single server.

--- a/connectrpc-grpcreflect/connectrpc_grpcreflect/_gen/grpc/reflection/v1alpha/reflection_connect.py
+++ b/connectrpc-grpcreflect/connectrpc_grpcreflect/_gen/grpc/reflection/v1alpha/reflection_connect.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 
 
 class ServerReflection(Protocol):
-    def server_reflection_info(self, request: AsyncIterator[ServerReflectionRequest], ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse]) -> AsyncIterator[ServerReflectionResponse]:
+    def server_reflection_info(self, request: AsyncIterator[ServerReflectionRequest], ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse], /) -> AsyncIterator[ServerReflectionResponse]:
         """
         The reflection service is structured as a bidirectional stream, ensuring
         all related requests go to a single server.
@@ -102,7 +102,7 @@ class ServerReflectionClient(ConnectClient):
         )
 
 class ServerReflectionSync(Protocol):
-    def server_reflection_info(self, request: Iterator[ServerReflectionRequest], ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse]) -> Iterator[ServerReflectionResponse]:
+    def server_reflection_info(self, request: Iterator[ServerReflectionRequest], ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse], /) -> Iterator[ServerReflectionResponse]:
         """
         The reflection service is structured as a bidirectional stream, ensuring
         all related requests go to a single server.

--- a/connectrpc-grpcreflect/connectrpc_grpcreflect/_service.py
+++ b/connectrpc-grpcreflect/connectrpc_grpcreflect/_service.py
@@ -67,7 +67,7 @@ class ServerReflectionService(ServerReflection):
     async def server_reflection_info(
         self,
         request: AsyncIterator[ServerReflectionRequest],
-        ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse],
+        _ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse],
     ) -> AsyncIterator[ServerReflectionResponse]:
         seen: set[str] = set()
         async for req in request:
@@ -99,7 +99,7 @@ class ServerReflectionServiceSync(ServerReflectionSync):
     def server_reflection_info(
         self,
         request: Iterator[ServerReflectionRequest],
-        ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse],
+        _ctx: RequestContext[ServerReflectionRequest, ServerReflectionResponse],
     ) -> Iterator[ServerReflectionResponse]:
         seen: set[str] = set()
         for req in request:
@@ -135,7 +135,7 @@ class ServerReflectionAlphaService(ServerReflectionAlpha):
     async def server_reflection_info(
         self,
         request: AsyncIterator[ServerReflectionAlphaRequest],
-        ctx: RequestContext[
+        _ctx: RequestContext[
             ServerReflectionAlphaRequest, ServerReflectionAlphaResponse
         ],
     ) -> AsyncIterator[ServerReflectionAlphaResponse]:
@@ -176,7 +176,7 @@ class ServerReflectionAlphaServiceSync(ServerReflectionAlphaSync):
     def server_reflection_info(
         self,
         request: Iterator[ServerReflectionAlphaRequest],
-        ctx: RequestContext[
+        _ctx: RequestContext[
             ServerReflectionAlphaRequest, ServerReflectionAlphaResponse
         ],
     ) -> Iterator[ServerReflectionAlphaResponse]:

--- a/connectrpc-grpcreflect/test/connectrpc/example/haberdasher_connect.py
+++ b/connectrpc-grpcreflect/test/connectrpc/example/haberdasher_connect.py
@@ -32,37 +32,37 @@ class Haberdasher(Protocol):
     """
     A Haberdasher makes hats for clients.
     """
-    async def make_hat(self, request: Size, ctx: RequestContext[Size, Hat]) -> Hat:
+    async def make_hat(self, request: Size, ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeHat produces a hat of mysterious, randomly-selected color!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    async def make_flexible_hat(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat]) -> Hat:
+    async def make_flexible_hat(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeFlexibleHats produces a single hat adhering to many sizes.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat]) -> AsyncIterator[Hat]:
+    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat], /) -> AsyncIterator[Hat]:
         """
         MakeSimilarHats produces hats of mysterious, randomly-selected color following a single order!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_various_hats(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat]) -> AsyncIterator[Hat]:
+    def make_various_hats(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat], /) -> AsyncIterator[Hat]:
         """
         MakeVariousHats produces hats of mysterious, randomly-selected color following many orders!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part]) -> AsyncIterator[Hat.Part]:
+    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part], /) -> AsyncIterator[Hat.Part]:
         """
         ListParts lists available parts for making a hat.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    async def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty]) -> Empty:
+    async def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty], /) -> Empty:
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
     @classmethod
@@ -301,37 +301,37 @@ class HaberdasherSync(Protocol):
     """
     A Haberdasher makes hats for clients.
     """
-    def make_hat(self, request: Size, ctx: RequestContext[Size, Hat]) -> Hat:
+    def make_hat(self, request: Size, ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeHat produces a hat of mysterious, randomly-selected color!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_flexible_hat(self, request: Iterator[Size], ctx: RequestContext[Size, Hat]) -> Hat:
+    def make_flexible_hat(self, request: Iterator[Size], ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeFlexibleHats produces a single hat adhering to many sizes.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat]) -> Iterator[Hat]:
+    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat], /) -> Iterator[Hat]:
         """
         MakeSimilarHats produces hats of mysterious, randomly-selected color following a single order!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_various_hats(self, request: Iterator[Size], ctx: RequestContext[Size, Hat]) -> Iterator[Hat]:
+    def make_various_hats(self, request: Iterator[Size], ctx: RequestContext[Size, Hat], /) -> Iterator[Hat]:
         """
         MakeVariousHats produces hats of mysterious, randomly-selected color following many orders!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part]) -> Iterator[Hat.Part]:
+    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part], /) -> Iterator[Hat.Part]:
         """
         ListParts lists available parts for making a hat.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty]) -> Empty:
+    def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty], /) -> Empty:
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
     @classmethod

--- a/connectrpc-otel/connectrpc_otel/_instrumentor.py
+++ b/connectrpc-otel/connectrpc_otel/_instrumentor.py
@@ -37,7 +37,7 @@ class ConnectInstrumentor(BaseInstrumentor):
         register_post_import_hook(self._patch_client, "connectrpc.client")
         register_post_import_hook(self._patch_server, "connectrpc.server")
 
-    def _uninstrument(self, **kwargs: object) -> None:
+    def _uninstrument(self, **_kwargs: object) -> None:
         # TODO: Remove sys.modules check after
         # https://github.com/open-telemetry/opentelemetry-python-contrib/pull/4321
         if "connectrpc.client" in sys.modules:

--- a/connectrpc-otel/connectrpc_otel/_interceptor.py
+++ b/connectrpc-otel/connectrpc_otel/_interceptor.py
@@ -123,7 +123,7 @@ class OpenTelemetryInterceptor:
         self.on_end_sync(token, ctx, error)
 
     def on_end_sync(
-        self, token: Token, ctx: RequestContext, error: Exception | None
+        self, token: Token, _ctx: RequestContext, error: Exception | None
     ) -> None:
         cm, span, start_time, shared_attrs = token
         end_time = time.perf_counter()

--- a/connectrpc-otel/test/test_instrumentor.py
+++ b/connectrpc-otel/test/test_instrumentor.py
@@ -35,12 +35,12 @@ if TYPE_CHECKING:
 
 
 class ElizaServiceTest(ElizaService):
-    async def say(self, request: SayRequest, ctx: RequestContext) -> SayResponse:
+    async def say(self, _request: SayRequest, _ctx: RequestContext) -> SayResponse:
         return SayResponse(sentence="Hello")
 
 
 class ElizaServiceTestSync(ElizaServiceSync):
-    def say(self, request: SayRequest, ctx: RequestContext) -> SayResponse:
+    def say(self, request: SayRequest, _ctx: RequestContext) -> SayResponse:
         if request.sentence == "connect error":
             raise ConnectError(Code.FAILED_PRECONDITION, "connect error")
         if request.sentence == "unknown error":

--- a/connectrpc-otel/test/test_interceptor.py
+++ b/connectrpc-otel/test/test_interceptor.py
@@ -39,7 +39,7 @@ if TYPE_CHECKING:
 
 
 class ElizaServiceTest(ElizaService):
-    async def say(self, request: SayRequest, ctx: RequestContext) -> SayResponse:
+    async def say(self, request: SayRequest, _ctx: RequestContext) -> SayResponse:
         if request.sentence == "connect error":
             raise ConnectError(Code.FAILED_PRECONDITION, "connect error")
         if request.sentence == "unknown error":
@@ -48,7 +48,7 @@ class ElizaServiceTest(ElizaService):
 
 
 class ElizaServiceTestSync(ElizaServiceSync):
-    def say(self, request: SayRequest, ctx: RequestContext) -> SayResponse:
+    def say(self, request: SayRequest, _ctx: RequestContext) -> SayResponse:
         if request.sentence == "connect error":
             raise ConnectError(Code.FAILED_PRECONDITION, "connect error")
         if request.sentence == "unknown error":

--- a/example/example/eliza_service.py
+++ b/example/example/eliza_service.py
@@ -36,12 +36,12 @@ class DemoElizaService(ElizaService):
     def __init__(self, stream_delay_secs: float = 0):
         self.stream_delay_secs = stream_delay_secs
 
-    async def say(self, request: SayRequest, ctx: RequestContext) -> SayResponse:
+    async def say(self, request: SayRequest, _ctx: RequestContext) -> SayResponse:
         reply, _ = _eliza.reply(request.sentence)
         return SayResponse(sentence=reply)
 
     async def converse(
-        self, request: AsyncIterator[ConverseRequest], ctx: RequestContext
+        self, request: AsyncIterator[ConverseRequest], _ctx: RequestContext
     ) -> AsyncIterator[ConverseResponse]:
         async for req in request:
             reply, end = _eliza.reply(req.sentence)
@@ -50,7 +50,7 @@ class DemoElizaService(ElizaService):
                 return
 
     async def introduce(
-        self, request: IntroduceRequest, ctx: RequestContext
+        self, request: IntroduceRequest, _ctx: RequestContext
     ) -> AsyncIterator[IntroduceResponse]:
         name = request.name
         if not name:

--- a/example/example/eliza_service_sync.py
+++ b/example/example/eliza_service_sync.py
@@ -33,12 +33,12 @@ class DemoElizaServiceSync(ElizaServiceSync):
     def __init__(self, stream_delay_secs: float = 0):
         self.stream_delay_secs = stream_delay_secs
 
-    def say(self, request: SayRequest, ctx: RequestContext) -> SayResponse:
+    def say(self, request: SayRequest, _ctx: RequestContext) -> SayResponse:
         reply, _ = _eliza.reply(request.sentence)
         return SayResponse(sentence=reply)
 
     def converse(
-        self, request: Iterator[ConverseRequest], ctx: RequestContext
+        self, request: Iterator[ConverseRequest], _ctx: RequestContext
     ) -> Iterator[ConverseResponse]:
         for req in request:
             reply, end = _eliza.reply(req.sentence)
@@ -47,7 +47,7 @@ class DemoElizaServiceSync(ElizaServiceSync):
                 return
 
     def introduce(
-        self, request: IntroduceRequest, ctx: RequestContext
+        self, request: IntroduceRequest, _ctx: RequestContext
     ) -> Iterator[IntroduceResponse]:
         name = request.name
         if not name:

--- a/example/example/gen/connectrpc/eliza/v1/eliza_connect.py
+++ b/example/example/gen/connectrpc/eliza/v1/eliza_connect.py
@@ -36,13 +36,13 @@ class ElizaService(Protocol):
     psychotherapist, and is commonly found as an Easter egg in emacs
     distributions.
     """
-    async def say(self, request: SayRequest, ctx: RequestContext[SayRequest, SayResponse]) -> SayResponse:
+    async def say(self, request: SayRequest, ctx: RequestContext[SayRequest, SayResponse], /) -> SayResponse:
         """
         Say is a unary RPC. Eliza responds to the prompt with a single sentence.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def converse(self, request: AsyncIterator[ConverseRequest], ctx: RequestContext[ConverseRequest, ConverseResponse]) -> AsyncIterator[ConverseResponse]:
+    def converse(self, request: AsyncIterator[ConverseRequest], ctx: RequestContext[ConverseRequest, ConverseResponse], /) -> AsyncIterator[ConverseResponse]:
         """
         Converse is a bidirectional RPC. The caller may exchange multiple
         back-and-forth messages with Eliza over a long-lived connection. Eliza
@@ -50,7 +50,7 @@ class ElizaService(Protocol):
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def introduce(self, request: IntroduceRequest, ctx: RequestContext[IntroduceRequest, IntroduceResponse]) -> AsyncIterator[IntroduceResponse]:
+    def introduce(self, request: IntroduceRequest, ctx: RequestContext[IntroduceRequest, IntroduceResponse], /) -> AsyncIterator[IntroduceResponse]:
         """
         Introduce is a server streaming RPC. Given the caller's name, Eliza
         returns a stream of sentences to introduce itself.
@@ -210,13 +210,13 @@ class ElizaServiceSync(Protocol):
     psychotherapist, and is commonly found as an Easter egg in emacs
     distributions.
     """
-    def say(self, request: SayRequest, ctx: RequestContext[SayRequest, SayResponse]) -> SayResponse:
+    def say(self, request: SayRequest, ctx: RequestContext[SayRequest, SayResponse], /) -> SayResponse:
         """
         Say is a unary RPC. Eliza responds to the prompt with a single sentence.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def converse(self, request: Iterator[ConverseRequest], ctx: RequestContext[ConverseRequest, ConverseResponse]) -> Iterator[ConverseResponse]:
+    def converse(self, request: Iterator[ConverseRequest], ctx: RequestContext[ConverseRequest, ConverseResponse], /) -> Iterator[ConverseResponse]:
         """
         Converse is a bidirectional RPC. The caller may exchange multiple
         back-and-forth messages with Eliza over a long-lived connection. Eliza
@@ -224,7 +224,7 @@ class ElizaServiceSync(Protocol):
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def introduce(self, request: IntroduceRequest, ctx: RequestContext[IntroduceRequest, IntroduceResponse]) -> Iterator[IntroduceResponse]:
+    def introduce(self, request: IntroduceRequest, ctx: RequestContext[IntroduceRequest, IntroduceResponse], /) -> Iterator[IntroduceResponse]:
         """
         Introduce is a server streaming RPC. Given the caller's name, Eliza
         returns a stream of sentences to introduce itself.

--- a/protoc-gen-connectrpc/protoc_gen_connectrpc/__init__.py
+++ b/protoc-gen-connectrpc/protoc_gen_connectrpc/__init__.py
@@ -135,7 +135,7 @@ def _generate_async_stubs(f: File, service: DescService, options: Options) -> No
                 _message_ident(method, method.input, options),
                 ", ",
                 _message_ident(method, method.output, options),
-                "]) -> ",
+                "], /) -> ",
                 *response_type,
                 ":",
             ):
@@ -321,7 +321,7 @@ def _generate_sync_stubs(f: File, service: DescService, options: Options) -> Non
                 _message_ident(method, method.input, options),
                 ", ",
                 _message_ident(method, method.output, options),
-                "]) -> ",
+                "], /) -> ",
                 *response_type,
                 ":",
             ):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,8 +193,6 @@ ignore = [
   "INT",
   # Even prevents pytest.raises around an iteration which is too strict
   "PT012",
-  # Triggers for protocol implementations that don't need the arg too
-  "ARG002",
   # Complexity checks usually reduce readability
   "C90",
   # Not Applicable

--- a/src/connectrpc/_client_async.py
+++ b/src/connectrpc/_client_async.py
@@ -57,24 +57,24 @@ RES = TypeVar("RES")
 
 
 class _ExecuteUnary(Protocol[REQ, RES]):
-    async def __call__(self, request: REQ, ctx: RequestContext[REQ, RES]) -> RES: ...
+    async def __call__(self, request: REQ, ctx: RequestContext[REQ, RES], /) -> RES: ...
 
 
 class _ExecuteClientStream(Protocol[REQ, RES]):
     async def __call__(
-        self, request: AsyncIterator[REQ], ctx: RequestContext[REQ, RES]
+        self, request: AsyncIterator[REQ], ctx: RequestContext[REQ, RES], /
     ) -> RES: ...
 
 
 class _ExecuteServerStream(Protocol[REQ, RES]):
     def __call__(
-        self, request: REQ, ctx: RequestContext[REQ, RES]
+        self, request: REQ, ctx: RequestContext[REQ, RES], /
     ) -> AsyncIterator[RES]: ...
 
 
 class _ExecuteBidiStream(Protocol[REQ, RES]):
     def __call__(
-        self, request: AsyncIterator[REQ], ctx: RequestContext[REQ, RES]
+        self, request: AsyncIterator[REQ], ctx: RequestContext[REQ, RES], /
     ) -> AsyncIterator[RES]: ...
 
 
@@ -291,7 +291,7 @@ class ConnectClient:
         return self._execute_bidi_stream(request, ctx)
 
     async def _send_request_unary(
-        self, request: REQ, ctx: RequestContext[REQ, RES]
+        self, request: REQ, ctx: RequestContext[REQ, RES], /
     ) -> RES:
         if isinstance(self._protocol, GRPCClientProtocol):
             return await _consume_single_response(
@@ -360,19 +360,19 @@ class ConnectClient:
             raise ConnectError(Code.UNAVAILABLE, str(e)) from e
 
     async def _send_request_client_stream(
-        self, request: AsyncIterator[REQ], ctx: RequestContext[REQ, RES]
+        self, request: AsyncIterator[REQ], ctx: RequestContext[REQ, RES], /
     ) -> RES:
         return await _consume_single_response(
             self._send_request_bidi_stream(request, ctx)
         )
 
     def _send_request_server_stream(
-        self, request: REQ, ctx: RequestContext[REQ, RES]
+        self, request: REQ, ctx: RequestContext[REQ, RES], /
     ) -> AsyncIterator[RES]:
         return self._send_request_bidi_stream(_yield_single_message(request), ctx)
 
     async def _send_request_bidi_stream(
-        self, request: AsyncIterator[REQ], ctx: RequestContext[REQ, RES]
+        self, request: AsyncIterator[REQ], ctx: RequestContext[REQ, RES], /
     ) -> AsyncIterator[RES]:
         request_headers = HTTPHeaders(ctx.request_headers.allitems())
         url = f"{self._address}/{ctx.method.service_name}/{ctx.method.name}"

--- a/src/connectrpc/_client_sync.py
+++ b/src/connectrpc/_client_sync.py
@@ -50,24 +50,24 @@ RES = TypeVar("RES")
 
 
 class _ExecuteUnary(Protocol[REQ, RES]):
-    def __call__(self, request: REQ, ctx: RequestContext[REQ, RES]) -> RES: ...
+    def __call__(self, request: REQ, ctx: RequestContext[REQ, RES], /) -> RES: ...
 
 
 class _ExecuteClientStream(Protocol[REQ, RES]):
     def __call__(
-        self, request: Iterator[REQ], ctx: RequestContext[REQ, RES]
+        self, request: Iterator[REQ], ctx: RequestContext[REQ, RES], /
     ) -> RES: ...
 
 
 class _ExecuteServerStream(Protocol[REQ, RES]):
     def __call__(
-        self, request: REQ, ctx: RequestContext[REQ, RES]
+        self, request: REQ, ctx: RequestContext[REQ, RES], /
     ) -> Iterator[RES]: ...
 
 
 class _ExecuteBidiStream(Protocol[REQ, RES]):
     def __call__(
-        self, request: Iterator[REQ], ctx: RequestContext[REQ, RES]
+        self, request: Iterator[REQ], ctx: RequestContext[REQ, RES], /
     ) -> Iterator[RES]: ...
 
 
@@ -355,17 +355,17 @@ class ConnectClientSync:
             raise ConnectError(Code.UNAVAILABLE, str(e)) from e
 
     def _send_request_client_stream(
-        self, request: Iterator[REQ], ctx: RequestContext[REQ, RES]
+        self, request: Iterator[REQ], ctx: RequestContext[REQ, RES], /
     ) -> RES:
         return _consume_single_response(self._send_request_bidi_stream(request, ctx))
 
     def _send_request_server_stream(
-        self, request: REQ, ctx: RequestContext[REQ, RES]
+        self, request: REQ, ctx: RequestContext[REQ, RES], /
     ) -> Iterator[RES]:
         return self._send_request_bidi_stream(iter([request]), ctx)
 
     def _send_request_bidi_stream(
-        self, request: Iterator[REQ], ctx: RequestContext[REQ, RES]
+        self, request: Iterator[REQ], ctx: RequestContext[REQ, RES], /
     ) -> Iterator[RES]:
         request_headers = HTTPHeaders(ctx.request_headers.allitems())
         url = f"{self._address}/{ctx.method.service_name}/{ctx.method.name}"

--- a/src/connectrpc/_envelope.py
+++ b/src/connectrpc/_envelope.py
@@ -84,7 +84,7 @@ class EnvelopeReader(Generic[_RES]):
             self._next_message_length = int.from_bytes(self._buffer[1:5], "big")
 
     def handle_end_message(
-        self, prefix_byte: int, message_data: bytes | bytearray
+        self, _prefix_byte: int, _message_data: bytes | bytearray, /
     ) -> bool:
         """For client protocols with an end message like Connect and gRPC-Web, handle the end message.
         Returns True if the end message was handled, False otherwise.
@@ -92,7 +92,7 @@ class EnvelopeReader(Generic[_RES]):
         return False
 
     def handle_response_complete(
-        self, response: Response | SyncResponse, e: ConnectError | None = None
+        self, response: Response | SyncResponse, /, e: ConnectError | None = None
     ) -> None:
         """Handle any client finalization needed when the response is complete.
         This is typically used to process trailers for gRPC.

--- a/src/connectrpc/_interceptor_async.py
+++ b/src/connectrpc/_interceptor_async.py
@@ -21,6 +21,7 @@ class UnaryInterceptor(Protocol):
         call_next: Callable[[REQ, RequestContext], Awaitable[RES]],
         request: REQ,
         ctx: RequestContext,
+        /,
     ) -> RES:
         """Intercepts a unary RPC.
 
@@ -48,6 +49,7 @@ class ClientStreamInterceptor(Protocol):
         call_next: Callable[[AsyncIterator[REQ], RequestContext], Awaitable[RES]],
         request: AsyncIterator[REQ],
         ctx: RequestContext,
+        /,
     ) -> RES:
         """Intercepts a client-streaming RPC.
 
@@ -75,6 +77,7 @@ class ServerStreamInterceptor(Protocol):
         call_next: Callable[[REQ, RequestContext], AsyncIterator[RES]],
         request: REQ,
         ctx: RequestContext,
+        /,
     ) -> AsyncIterator[RES]:
         """Intercepts a server-streaming RPC.
 
@@ -102,6 +105,7 @@ class BidiStreamInterceptor(Protocol):
         call_next: Callable[[AsyncIterator[REQ], RequestContext], AsyncIterator[RES]],
         request: AsyncIterator[REQ],
         ctx: RequestContext,
+        /,
     ) -> AsyncIterator[RES]:
         """Intercepts a bidirectional-streaming RPC.
 
@@ -137,7 +141,11 @@ class MetadataInterceptor(Protocol[T]):
         ...
 
     async def on_end(
-        self, token: T, ctx: RequestContext, error: Exception | None
+        self,
+        token: T,  # noqa: ARG002 # keep name clean for public API
+        ctx: RequestContext,  # noqa: ARG002 # keep name clean for public API
+        error: Exception | None,  # noqa: ARG002 # keep name clean for public API
+        /,
     ) -> None:
         """Called when the RPC ends."""
         return

--- a/src/connectrpc/_interceptor_sync.py
+++ b/src/connectrpc/_interceptor_sync.py
@@ -21,6 +21,7 @@ class UnaryInterceptorSync(Protocol):
         call_next: Callable[[REQ, RequestContext], RES],
         request: REQ,
         ctx: RequestContext,
+        /,
     ) -> RES:
         """Intercepts a unary RPC.
 
@@ -48,6 +49,7 @@ class ClientStreamInterceptorSync(Protocol):
         call_next: Callable[[Iterator[REQ], RequestContext], RES],
         request: Iterator[REQ],
         ctx: RequestContext,
+        /,
     ) -> RES:
         """Intercepts a client-streaming RPC.
 
@@ -75,6 +77,7 @@ class ServerStreamInterceptorSync(Protocol):
         call_next: Callable[[REQ, RequestContext], Iterator[RES]],
         request: REQ,
         ctx: RequestContext,
+        /,
     ) -> Iterator[RES]:
         """Intercepts a server-streaming RPC.
 
@@ -102,6 +105,7 @@ class BidiStreamInterceptorSync(Protocol):
         call_next: Callable[[Iterator[REQ], RequestContext], Iterator[RES]],
         request: Iterator[REQ],
         ctx: RequestContext,
+        /,
     ) -> Iterator[RES]:
         """Intercepts a bidirectional-streaming RPC.
 
@@ -129,7 +133,7 @@ class MetadataInterceptorSync(Protocol[T]):
     corresponding to the type of method such as [UnaryInterceptorSync][].
     """
 
-    def on_start_sync(self, ctx: RequestContext) -> T:
+    def on_start_sync(self, ctx: RequestContext, /) -> T:
         """Called when the RPC starts. The return value will be passed to [on_end_sync][] as-is.
         For example, if measuring RPC invocation time, on_start_sync may return the current
         time. If a return value isn't needed or [on_end_sync][] won't be used, return None.
@@ -137,7 +141,11 @@ class MetadataInterceptorSync(Protocol[T]):
         ...
 
     def on_end_sync(
-        self, token: T, ctx: RequestContext, error: Exception | None
+        self,
+        token: T,  # noqa: ARG002 # keep name clean for public API
+        ctx: RequestContext,  # noqa: ARG002 # keep name clean for public API
+        error: Exception | None,  # noqa: ARG002 # keep name clean for public API
+        /,
     ) -> None:
         """Called when the RPC ends."""
         return

--- a/src/connectrpc/_protocol_connect.py
+++ b/src/connectrpc/_protocol_connect.py
@@ -315,7 +315,7 @@ class ConnectClientProtocol:
 
 class ConnectEnvelopeReader(EnvelopeReader[RES]):
     def handle_end_message(
-        self, prefix_byte: int, message_data: bytes | bytearray
+        self, prefix_byte: int, message_data: bytes | bytearray, /
     ) -> bool:
         end_stream = prefix_byte & 0b10 != 0
         if not end_stream:

--- a/src/connectrpc/_protocol_grpc.py
+++ b/src/connectrpc/_protocol_grpc.py
@@ -88,7 +88,7 @@ class GRPCServerProtocol:
     def compression_header_name(self) -> str:
         return GRPC_HEADER_COMPRESSION
 
-    def codec_name_from_content_type(self, content_type: str, *, stream: bool) -> str:
+    def codec_name_from_content_type(self, content_type: str, *, stream: bool) -> str:  # noqa: ARG002
         if content_type.startswith(GRPC_CONTENT_TYPE_PREFIX):
             return content_type[len(GRPC_CONTENT_TYPE_PREFIX) :]
         return "proto"
@@ -110,7 +110,7 @@ class GRPCWebServerProtocol(GRPCServerProtocol):
     def content_type(self, codec: Codec) -> str:
         return f"{GRPC_WEB_CONTENT_TYPE_PREFIX}{codec.name()}"
 
-    def codec_name_from_content_type(self, content_type: str, *, stream: bool) -> str:
+    def codec_name_from_content_type(self, content_type: str, *, stream: bool) -> str:  # noqa: ARG002
         if content_type.startswith(GRPC_WEB_CONTENT_TYPE_PREFIX):
             return content_type[len(GRPC_WEB_CONTENT_TYPE_PREFIX) :]
         return "proto"
@@ -206,7 +206,7 @@ class GRPCClientProtocol:
         user_headers: Headers | Mapping[str, str] | None,
         timeout_ms: int | None,
         codec: Codec,
-        stream: bool,
+        stream: bool,  # noqa: ARG002
         accept_compression: str,
         send_compression: Compression | None,
     ) -> RequestContext[REQ, RES]:
@@ -271,7 +271,11 @@ class GRPCClientProtocol:
             )
 
     def handle_response_compression(
-        self, headers: HTTPHeaders, compressions: dict[str, Compression], stream: bool
+        self,
+        headers: HTTPHeaders,
+        compressions: dict[str, Compression],
+        *,
+        stream: bool,  # noqa: ARG002
     ) -> Compression:
         encoding = headers.get(GRPC_HEADER_COMPRESSION)
         if not encoding:
@@ -321,7 +325,7 @@ class GRPCEnvelopeReader(EnvelopeReader[RES]):
         self._read_message = False
 
     def handle_end_message(
-        self, prefix_byte: int, message_data: bytes | bytearray
+        self, _prefix_byte: int, _message_data: bytes | bytearray, /
     ) -> bool:
         # It's coincidence that this method is called when there is a body and not
         # when there isn't. Somewhat hacky, but easiest way to handle the case
@@ -329,7 +333,9 @@ class GRPCEnvelopeReader(EnvelopeReader[RES]):
         self._read_message = True
         return False
 
-    def get_response_trailers(self, response: Response | SyncResponse) -> HTTPHeaders:
+    def get_response_trailers(
+        self, response: Response | SyncResponse, /
+    ) -> HTTPHeaders:
         return response.trailers
 
     def handle_response_complete(
@@ -395,7 +401,9 @@ class GRPCWebEnvelopeReader(GRPCEnvelopeReader):
             self._trailers.add(key.decode().strip(), value.decode().strip())
         return True
 
-    def get_response_trailers(self, response: Response | SyncResponse) -> HTTPHeaders:
+    def get_response_trailers(
+        self, _response: Response | SyncResponse, /
+    ) -> HTTPHeaders:
         return self._trailers
 
 

--- a/test/connectrpc/example/haberdasher_connect.py
+++ b/test/connectrpc/example/haberdasher_connect.py
@@ -32,37 +32,37 @@ class Haberdasher(Protocol):
     """
     A Haberdasher makes hats for clients.
     """
-    async def make_hat(self, request: Size, ctx: RequestContext[Size, Hat]) -> Hat:
+    async def make_hat(self, request: Size, ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeHat produces a hat of mysterious, randomly-selected color!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    async def make_flexible_hat(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat]) -> Hat:
+    async def make_flexible_hat(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeFlexibleHats produces a single hat adhering to many sizes.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat]) -> AsyncIterator[Hat]:
+    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat], /) -> AsyncIterator[Hat]:
         """
         MakeSimilarHats produces hats of mysterious, randomly-selected color following a single order!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_various_hats(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat]) -> AsyncIterator[Hat]:
+    def make_various_hats(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat], /) -> AsyncIterator[Hat]:
         """
         MakeVariousHats produces hats of mysterious, randomly-selected color following many orders!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part]) -> AsyncIterator[Hat.Part]:
+    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part], /) -> AsyncIterator[Hat.Part]:
         """
         ListParts lists available parts for making a hat.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    async def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty]) -> Empty:
+    async def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty], /) -> Empty:
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
     @classmethod
@@ -301,37 +301,37 @@ class HaberdasherSync(Protocol):
     """
     A Haberdasher makes hats for clients.
     """
-    def make_hat(self, request: Size, ctx: RequestContext[Size, Hat]) -> Hat:
+    def make_hat(self, request: Size, ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeHat produces a hat of mysterious, randomly-selected color!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_flexible_hat(self, request: Iterator[Size], ctx: RequestContext[Size, Hat]) -> Hat:
+    def make_flexible_hat(self, request: Iterator[Size], ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeFlexibleHats produces a single hat adhering to many sizes.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat]) -> Iterator[Hat]:
+    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat], /) -> Iterator[Hat]:
         """
         MakeSimilarHats produces hats of mysterious, randomly-selected color following a single order!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_various_hats(self, request: Iterator[Size], ctx: RequestContext[Size, Hat]) -> Iterator[Hat]:
+    def make_various_hats(self, request: Iterator[Size], ctx: RequestContext[Size, Hat], /) -> Iterator[Hat]:
         """
         MakeVariousHats produces hats of mysterious, randomly-selected color following many orders!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part]) -> Iterator[Hat.Part]:
+    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part], /) -> Iterator[Hat.Part]:
         """
         ListParts lists available parts for making a hat.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty]) -> Empty:
+    def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty], /) -> Empty:
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
     @classmethod

--- a/test/google_compat/connectrpc/example/haberdasher_connect.py
+++ b/test/google_compat/connectrpc/example/haberdasher_connect.py
@@ -39,37 +39,37 @@ class Haberdasher(Protocol):
     """
     A Haberdasher makes hats for clients.
     """
-    async def make_hat(self, request: Size, ctx: RequestContext[Size, Hat]) -> Hat:
+    async def make_hat(self, request: Size, ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeHat produces a hat of mysterious, randomly-selected color!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    async def make_flexible_hat(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat]) -> Hat:
+    async def make_flexible_hat(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeFlexibleHats produces a single hat adhering to many sizes.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat]) -> AsyncIterator[Hat]:
+    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat], /) -> AsyncIterator[Hat]:
         """
         MakeSimilarHats produces hats of mysterious, randomly-selected color following a single order!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_various_hats(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat]) -> AsyncIterator[Hat]:
+    def make_various_hats(self, request: AsyncIterator[Size], ctx: RequestContext[Size, Hat], /) -> AsyncIterator[Hat]:
         """
         MakeVariousHats produces hats of mysterious, randomly-selected color following many orders!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part]) -> AsyncIterator[Hat.Part]:
+    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part], /) -> AsyncIterator[Hat.Part]:
         """
         ListParts lists available parts for making a hat.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    async def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty]) -> Empty:
+    async def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty], /) -> Empty:
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
 
@@ -328,37 +328,37 @@ class HaberdasherSync(Protocol):
     """
     A Haberdasher makes hats for clients.
     """
-    def make_hat(self, request: Size, ctx: RequestContext[Size, Hat]) -> Hat:
+    def make_hat(self, request: Size, ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeHat produces a hat of mysterious, randomly-selected color!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_flexible_hat(self, request: Iterator[Size], ctx: RequestContext[Size, Hat]) -> Hat:
+    def make_flexible_hat(self, request: Iterator[Size], ctx: RequestContext[Size, Hat], /) -> Hat:
         """
         MakeFlexibleHats produces a single hat adhering to many sizes.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat]) -> Iterator[Hat]:
+    def make_similar_hats(self, request: Size, ctx: RequestContext[Size, Hat], /) -> Iterator[Hat]:
         """
         MakeSimilarHats produces hats of mysterious, randomly-selected color following a single order!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def make_various_hats(self, request: Iterator[Size], ctx: RequestContext[Size, Hat]) -> Iterator[Hat]:
+    def make_various_hats(self, request: Iterator[Size], ctx: RequestContext[Size, Hat], /) -> Iterator[Hat]:
         """
         MakeVariousHats produces hats of mysterious, randomly-selected color following many orders!
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part]) -> Iterator[Hat.Part]:
+    def list_parts(self, request: Empty, ctx: RequestContext[Empty, Hat.Part], /) -> Iterator[Hat.Part]:
         """
         ListParts lists available parts for making a hat.
         """
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
-    def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty]) -> Empty:
+    def do_nothing(self, request: Empty, ctx: RequestContext[Empty, Empty], /) -> Empty:
         raise ConnectError(Code.UNIMPLEMENTED, 'Not implemented')
 
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -57,7 +57,7 @@ def test_headers_sync(headers, trailers, response_headers, response_trailers) ->
             self.headers = headers
             self.trailers = trailers
 
-        def make_hat(self, request, ctx):
+        def make_hat(self, _request, ctx):
             for key, value in self.headers:
                 ctx.response_headers.add(key, value)
             for key, value in self.trailers:
@@ -93,7 +93,7 @@ async def test_headers_async(
             self.headers = headers
             self.trailers = trailers
 
-        async def make_hat(self, request, ctx):
+        async def make_hat(self, _request, ctx):
             for key, value in self.headers:
                 ctx.response_headers.add(key, value)
             for key, value in self.trailers:

--- a/test/test_codec.py
+++ b/test/test_codec.py
@@ -54,12 +54,12 @@ class CustomCodec(Codec[Message, Message]):
 
 
 class SimpleHaberdasher(Haberdasher):
-    async def make_hat(self, request: Size, ctx):
+    async def make_hat(self, request: Size, _ctx):
         return Hat(size=request.inches, color="blue")
 
 
-class SimpleHabersahserSync(HaberdasherSync):
-    def make_hat(self, request: Size, ctx):
+class SimpleHaberdasherSync(HaberdasherSync):
+    def make_hat(self, request: Size, _ctx):
         return Hat(size=request.inches, color="blue")
 
 
@@ -133,7 +133,7 @@ def test_custom_codec_sync() -> None:
 
     transport = LoggingSyncTransport(
         WSGITransport(
-            HaberdasherWSGIApplication(SimpleHabersahserSync(), codecs=[CustomCodec()])
+            HaberdasherWSGIApplication(SimpleHaberdasherSync(), codecs=[CustomCodec()])
         )
     )
     client = HaberdasherClientSync(

--- a/test/test_compression.py
+++ b/test/test_compression.py
@@ -37,7 +37,7 @@ async def test_server_compressions_async(
     compressions: tuple[str], encoding: str
 ) -> None:
     class SimpleHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx):
+        async def make_hat(self, _request, _ctx):
             return Hat(size=10, color="blue")
 
     app = HaberdasherASGIApplication(
@@ -72,7 +72,7 @@ async def test_server_compressions_async(
 )
 def test_server_compressions_sync(compressions: tuple[str], encoding: str) -> None:
     class SimpleHaberdasher(HaberdasherSync):
-        def make_hat(self, request, ctx):
+        def make_hat(self, _request, _ctx):
             return Hat(size=10, color="blue")
 
     app = HaberdasherWSGIApplication(

--- a/test/test_details.py
+++ b/test/test_details.py
@@ -26,7 +26,7 @@ from .connectrpc.example.haberdasher_pb import Size
 
 def test_details_sync() -> None:
     class DetailsHaberdasherSync(HaberdasherSync):
-        def make_hat(self, request, ctx) -> NoReturn:
+        def make_hat(self, _request, _ctx) -> NoReturn:
             raise ConnectError(
                 Code.RESOURCE_EXHAUSTED,
                 "Resource exhausted",
@@ -66,7 +66,7 @@ def test_details_sync() -> None:
 @pytest.mark.asyncio
 async def test_details_async() -> None:
     class DetailsHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx) -> NoReturn:
+        async def make_hat(self, _request, _ctx) -> NoReturn:
             raise ConnectError(
                 Code.RESOURCE_EXHAUSTED,
                 "Resource exhausted",

--- a/test/test_errors.py
+++ b/test/test_errors.py
@@ -62,7 +62,7 @@ def test_sync_errors(code: Code, message: str, http_status: int) -> None:
         def __init__(self, exception: ConnectError) -> None:
             self._exception = exception
 
-        def make_hat(self, request, ctx) -> NoReturn:
+        def make_hat(self, _request, _ctx) -> NoReturn:
             raise self._exception
 
     haberdasher = ErrorHaberdasherSync(ConnectError(code, message))
@@ -102,7 +102,7 @@ async def test_async_errors(code: Code, message: str, http_status: int) -> None:
         def __init__(self, exception: ConnectError) -> None:
             self._exception = exception
 
-        async def make_hat(self, request, ctx) -> NoReturn:
+        async def make_hat(self, _request, _ctx) -> NoReturn:
             raise self._exception
 
     haberdasher = ErrorHaberdasher(ConnectError(code, message))
@@ -187,7 +187,7 @@ def test_sync_http_errors(
     response_status, content, response_headers, code, message
 ) -> None:
     class MockTransport(SyncTransport):
-        def execute_sync(self, request: SyncRequest) -> SyncResponse:
+        def execute_sync(self, request: SyncRequest) -> SyncResponse:  # noqa: ARG002
             return SyncResponse(
                 status=response_status,
                 content=content,
@@ -213,7 +213,7 @@ async def test_async_http_errors(
     response_status, content, response_headers, code, message
 ) -> None:
     class MockTransport(Transport):
-        async def execute(self, request: Request) -> Response:
+        async def execute(self, request: Request) -> Response:  # noqa: ARG002
             return Response(
                 status=response_status,
                 content=content,
@@ -313,7 +313,7 @@ def test_sync_client_errors(
     method, path, headers, body, response_status, response_headers
 ) -> None:
     class ValidHaberdasherSync(HaberdasherSync):
-        def make_hat(self, request, ctx):
+        def make_hat(self, _request, _ctx):
             return Hat()
 
     app = HaberdasherWSGIApplication(ValidHaberdasherSync())
@@ -337,7 +337,7 @@ async def test_async_client_errors(
     method, path, headers, body, response_status, response_headers
 ) -> None:
     class ValidHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx):
+        async def make_hat(self, _request, _ctx):
             return Hat()
 
     haberdasher = ValidHaberdasher()
@@ -373,7 +373,7 @@ def test_sync_client_timeout(client_timeout_ms, call_timeout_ms) -> None:
     timed_out = threading.Event()
 
     class SleepingHaberdasher(HaberdasherSync):
-        def make_hat(self, request, ctx) -> NoReturn:
+        def make_hat(self, _request, _ctx) -> NoReturn:
             timed_out.wait()
             raise AssertionError("Timedout already")
 
@@ -412,7 +412,7 @@ async def test_async_client_timeout(client_timeout_ms, call_timeout_ms) -> None:
             return await self._transport.execute(request)
 
     class SleepingHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx) -> NoReturn:
+        async def make_hat(self, _request, _ctx) -> NoReturn:
             await asyncio.sleep(10)
             raise AssertionError("Should be timedout already")
 
@@ -433,7 +433,7 @@ async def test_async_client_timeout(client_timeout_ms, call_timeout_ms) -> None:
 @pytest.mark.asyncio
 async def test_async_unhandled_exception_reraised() -> None:
     class RaisingHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx) -> NoReturn:
+        async def make_hat(self, _request, _ctx) -> NoReturn:
             raise TypeError("Something went wrong")
 
     app = HaberdasherASGIApplication(RaisingHaberdasher())
@@ -453,7 +453,7 @@ async def test_async_unhandled_exception_reraised() -> None:
 @pytest.mark.asyncio
 async def test_async_unhandled_exception_reraised_stream() -> None:
     class RaisingHaberdasher(Haberdasher):
-        def make_similar_hats(self, request: Size, ctx: RequestContext) -> NoReturn:
+        def make_similar_hats(self, _request: Size, _ctx: RequestContext) -> NoReturn:
             raise TypeError("Something went wrong")
 
     app = HaberdasherASGIApplication(RaisingHaberdasher())
@@ -474,7 +474,7 @@ async def test_async_unhandled_exception_reraised_stream() -> None:
 @pytest.mark.asyncio
 async def test_async_connect_exception_not_reraised() -> None:
     class RaisingHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx) -> NoReturn:
+        async def make_hat(self, _request, _ctx) -> NoReturn:
             raise ConnectError(Code.INTERNAL, "We're broken")
 
     app = HaberdasherASGIApplication(RaisingHaberdasher())
@@ -493,7 +493,7 @@ async def test_async_connect_exception_not_reraised() -> None:
 @pytest.mark.asyncio
 async def test_async_connect_exception_not_reraised_stream() -> None:
     class RaisingHaberdasher(Haberdasher):
-        def make_similar_hats(self, request: Size, ctx: RequestContext) -> NoReturn:
+        def make_similar_hats(self, _request: Size, _ctx: RequestContext) -> NoReturn:
             raise ConnectError(Code.INTERNAL, "We're broken")
 
     app = HaberdasherASGIApplication(RaisingHaberdasher())
@@ -513,7 +513,7 @@ async def test_async_connect_exception_not_reraised_stream() -> None:
 @pytest.mark.asyncio
 async def test_async_http_exception_not_reraised() -> None:
     class RaisingHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx) -> NoReturn:
+        async def make_hat(self, _request, _ctx) -> NoReturn:
             raise HTTPException(status=HTTPStatus.INTERNAL_SERVER_ERROR, headers=[])
 
     app = HaberdasherASGIApplication(RaisingHaberdasher())
@@ -531,7 +531,7 @@ async def test_async_http_exception_not_reraised() -> None:
 
 def test_sync_unhandled_exception_logged() -> None:
     class RaisingHaberdasher(HaberdasherSync):
-        def make_hat(self, request, ctx) -> NoReturn:
+        def make_hat(self, _request, _ctx) -> NoReturn:
             raise TypeError("Something went wrong")
 
     app = HaberdasherWSGIApplication(RaisingHaberdasher())
@@ -554,7 +554,7 @@ def test_sync_unhandled_exception_logged() -> None:
 
 def test_sync_unhandled_exception_logged_stream() -> None:
     class RaisingHaberdasher(HaberdasherSync):
-        def make_similar_hats(self, request, ctx) -> NoReturn:
+        def make_similar_hats(self, _request, _ctx) -> NoReturn:
             raise TypeError("Something went wrong")
 
     app = HaberdasherWSGIApplication(RaisingHaberdasher())

--- a/test/test_http.py
+++ b/test/test_http.py
@@ -35,7 +35,7 @@ _charset_content_type_cases = [
 @pytest.mark.parametrize("header", _charset_content_type_cases)
 def test_json_charset_content_type(header: str) -> None:
     class HeadersHaberdasherSync(HaberdasherSync):
-        def make_hat(self, request, ctx):
+        def make_hat(self, _request, _ctx):
             return Hat(size=2)
 
     transport = WSGITransport(HaberdasherWSGIApplication(HeadersHaberdasherSync()))
@@ -55,7 +55,7 @@ def test_json_charset_content_type(header: str) -> None:
 @pytest.mark.parametrize("header", _charset_content_type_cases)
 async def test_json_charset_content_type_async(header: str) -> None:
     class HeadersHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx):
+        async def make_hat(self, _request, _ctx):
             return Hat(size=2)
 
     transport = ASGITransport(HaberdasherASGIApplication(HeadersHaberdasher()))
@@ -79,7 +79,7 @@ _streaming_charset_content_type_cases = [
 @pytest.mark.parametrize("header", _streaming_charset_content_type_cases)
 def test_json_charset_content_type_stream(header: str) -> None:
     class HeadersHaberdasherSync(HaberdasherSync):
-        def make_similar_hats(self, request, ctx):
+        def make_similar_hats(self, _request, _ctx):
             yield Hat(size=2)
             yield Hat(size=3)
 
@@ -111,7 +111,7 @@ def test_json_charset_content_type_stream(header: str) -> None:
 @pytest.mark.parametrize("header", _streaming_charset_content_type_cases)
 async def test_json_charset_content_type_stream_async(header: str) -> None:
     class HeadersHaberdasher(Haberdasher):
-        async def make_similar_hats(self, request, ctx):
+        async def make_similar_hats(self, _request, _ctx):
             yield Hat(size=2)
             yield Hat(size=3)
 

--- a/test/test_interceptor.py
+++ b/test/test_interceptor.py
@@ -41,7 +41,7 @@ class RequestInterceptor:
         return f"Hello {ctx.method.name}"
 
     def on_end_sync(
-        self, token: str, ctx: RequestContext, error: Exception | None
+        self, token: str, _ctx: RequestContext, error: Exception | None
     ) -> None:
         msg = f"{token} and goodbye"
         if error is not None:
@@ -64,12 +64,12 @@ async def client_async(
     client_interceptor: RequestInterceptor, server_interceptor: RequestInterceptor
 ):
     class SimpleHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx):
+        async def make_hat(self, request, _ctx):
             if request.inches < 0:
                 raise ConnectError(Code.INVALID_ARGUMENT, "Size must be non-negative")
             return Hat(size=request.inches, color="green")
 
-        async def make_flexible_hat(self, request, ctx):
+        async def make_flexible_hat(self, request, _ctx):
             size = 0
             async for s in request:
                 if s.inches < 0:
@@ -79,13 +79,13 @@ async def client_async(
                 size += s.inches
             return Hat(size=size, color="red")
 
-        async def make_similar_hats(self, request, ctx):
+        async def make_similar_hats(self, request, _ctx):
             if request.inches < 0:
                 raise ConnectError(Code.INVALID_ARGUMENT, "Size must be non-negative")
             yield Hat(size=request.inches, color="orange")
             yield Hat(size=request.inches, color="blue")
 
-        async def make_various_hats(self, request, ctx):
+        async def make_various_hats(self, request, _ctx):
             colors = itertools.cycle(("black", "white", "gold"))
             async for s in request:
                 if s.inches < 0:
@@ -251,12 +251,12 @@ def client_sync(
     client_interceptor: RequestInterceptor, server_interceptor: RequestInterceptor
 ):
     class SimpleHaberdasherSync(HaberdasherSync):
-        def make_hat(self, request, ctx):
+        def make_hat(self, request, _ctx):
             if request.inches < 0:
                 raise ConnectError(Code.INVALID_ARGUMENT, "Size must be non-negative")
             return Hat(size=request.inches, color="green")
 
-        def make_flexible_hat(self, request, ctx):
+        def make_flexible_hat(self, request, _ctx):
             size = 0
             for s in request:
                 if s.inches < 0:
@@ -266,13 +266,13 @@ def client_sync(
                 size += s.inches
             return Hat(size=size, color="red")
 
-        def make_similar_hats(self, request, ctx):
+        def make_similar_hats(self, request, _ctx):
             if request.inches < 0:
                 raise ConnectError(Code.INVALID_ARGUMENT, "Size must be non-negative")
             yield Hat(size=request.inches, color="orange")
             yield Hat(size=request.inches, color="blue")
 
-        def make_various_hats(self, request, ctx):
+        def make_various_hats(self, request, _ctx):
             colors = itertools.cycle(("black", "white", "gold"))
             requests = [*request]
             for s in requests:

--- a/test/test_lifespan.py
+++ b/test/test_lifespan.py
@@ -20,7 +20,7 @@ class CountingHaberdasher(Haberdasher):
     def __init__(self, counter: Counter) -> None:
         self._counter = counter
 
-    async def make_hat(self, request, ctx):
+    async def make_hat(self, request, _ctx):
         self._counter["requests"] += 1
         return Hat(size=request.inches, color="blue")
 

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 @pytest.mark.parametrize("compression_name", ["gzip", "br", "zstd", "identity"])
 def test_roundtrip_sync(proto_json: bool, compression_name: str) -> None:
     class RoundtripHaberdasherSync(HaberdasherSync):
-        def make_hat(self, request, ctx):
+        def make_hat(self, request, _ctx):
             return Hat(size=request.inches, color="green")
 
     compression = resolve_compression(compression_name)
@@ -57,7 +57,7 @@ def test_roundtrip_sync(proto_json: bool, compression_name: str) -> None:
 @pytest.mark.asyncio
 async def test_roundtrip_async(proto_json: bool, compression_name: str) -> None:
     class DetailsHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx):
+        async def make_hat(self, request, _ctx):
             return Hat(size=request.inches, color="green")
 
     compression = resolve_compression(compression_name)
@@ -77,7 +77,7 @@ async def test_roundtrip_async(proto_json: bool, compression_name: str) -> None:
 
 def test_roundtrip_sync_connect_get_empty_request() -> None:
     class RoundtripHaberdasherSync(HaberdasherSync):
-        def make_hat(self, request, ctx):
+        def make_hat(self, request, _ctx):
             return Hat(size=request.inches, color="green")
 
     compression = resolve_compression("identity")
@@ -98,7 +98,7 @@ def test_roundtrip_sync_connect_get_empty_request() -> None:
 @pytest.mark.asyncio
 async def test_roundtrip_async_connect_get_empty_request() -> None:
     class RoundtripHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx):
+        async def make_hat(self, request, _ctx):
             return Hat(size=request.inches, color="green")
 
     compression = resolve_compression("identity")
@@ -122,7 +122,7 @@ async def test_roundtrip_response_stream_async(
     proto_json: bool, compression_name: str
 ) -> None:
     class StreamingHaberdasher(Haberdasher):
-        async def make_similar_hats(self, request, ctx):
+        async def make_similar_hats(self, request, _ctx):
             yield Hat(size=request.inches, color="green")
             yield Hat(size=request.inches, color="red")
             yield Hat(size=request.inches, color="blue")
@@ -166,11 +166,11 @@ def test_message_limit_sync(client_bad: bool, compression_name: str) -> None:
     bad_hat = Hat(color="X" * 1000)
 
     class LargeHaberdasher(HaberdasherSync):
-        def make_hat(self, request, ctx):
+        def make_hat(self, request, _ctx):
             requests.append(request)
             return good_hat if client_bad else bad_hat
 
-        def make_various_hats(self, request: Iterator[Size], ctx) -> Iterator[Hat]:
+        def make_various_hats(self, request: Iterator[Size], _ctx) -> Iterator[Hat]:
             for size in request:
                 requests.append(size)
             yield Hat(color="good")
@@ -232,12 +232,12 @@ async def test_message_limit_async(client_bad: bool, compression_name: str) -> N
     bad_hat = Hat(color="X" * 1000)
 
     class LargeHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx):
+        async def make_hat(self, request, _ctx):
             requests.append(request)
             return good_hat if client_bad else bad_hat
 
         async def make_various_hats(
-            self, request: AsyncIterator[Size], ctx
+            self, request: AsyncIterator[Size], _ctx
         ) -> AsyncIterator[Hat]:
             async for size in request:
                 requests.append(size)
@@ -296,7 +296,7 @@ async def test_server_stream_client_disconnect() -> None:
     generator_closed = asyncio.Event()
 
     class InfiniteHaberdasher(Haberdasher):
-        async def make_similar_hats(self, request, ctx):
+        async def make_similar_hats(self, request, _ctx):
             try:
                 while True:
                     yield Hat(size=request.inches, color="green")

--- a/test/test_roundtrip_google_compat.py
+++ b/test/test_roundtrip_google_compat.py
@@ -20,7 +20,7 @@ from .google_compat.connectrpc.example.haberdasher_pb2 import Hat, Size
 @pytest.mark.parametrize("proto_json", [False, True])
 def test_roundtrip_sync(proto_json: bool) -> None:
     class RoundtripHaberdasherSync(HaberdasherSync):
-        def make_hat(self, request, ctx):
+        def make_hat(self, request, _ctx):
             return Hat(size=request.inches, color="green")
 
     app = HaberdasherWSGIApplication(RoundtripHaberdasherSync())
@@ -40,7 +40,7 @@ def test_roundtrip_sync(proto_json: bool) -> None:
 @pytest.mark.asyncio
 async def test_roundtrip_async(proto_json: bool) -> None:
     class DetailsHaberdasher(Haberdasher):
-        async def make_hat(self, request, ctx):
+        async def make_hat(self, request, _ctx):
             return Hat(size=request.inches, color="green")
 
     app = HaberdasherASGIApplication(DetailsHaberdasher())


### PR DESCRIPTION
There has been one usability issue with protocols that often parameters like context aren't needed, but ruff flags them as unused, and the standard `_` prefix for that case doesn't pass type checking. It's because the protocols accept keyword-passing. We never use keyword-passing with these so can mark positional-only, which should make it easier to write implementations. The downside is if a user wants to manually invoke their implementation with keyword passing, it doesn't work anymore. As we recommend test transports and no manual invocation of stubs, and it would still work with positional passing, this seems like a very good tradeoff for easier implementing.