### PR TITLE
Ignore unknown fields for JSON codec by default with knob

### DIFF
--- a/src/connectrpc/_codec.py
+++ b/src/connectrpc/_codec.py
@@ -78,9 +78,16 @@ class ProtoBinaryCodec(Codec[Message, V]):
 class ProtoJSONCodec(Codec[Message, V]):
     """Codec for the Protocol Buffers JSON format."""
 
-    def __init__(self, name: str = "json", registry: Registry | None = None) -> None:
+    def __init__(
+        self,
+        name: str = "json",
+        *,
+        registry: Registry | None = None,
+        ignore_unknown_fields: bool = True,
+    ) -> None:
         self._name = name
         self._registry = registry or DEFAULT_REGISTRY
+        self._ignore_unknown_fields = ignore_unknown_fields
 
     def name(self) -> str:
         return self._name
@@ -89,7 +96,11 @@ class ProtoJSONCodec(Codec[Message, V]):
         return message.to_json(registry=self._registry).encode()
 
     def decode(self, data: bytes | bytearray, message_class: type[V]) -> V:
-        return message_class.from_json(data, registry=self._registry)
+        return message_class.from_json(
+            data,
+            registry=self._registry,
+            ignore_unknown_fields=self._ignore_unknown_fields,
+        )
 
 
 _proto_binary_codec = ProtoBinaryCodec()
@@ -106,14 +117,22 @@ def proto_binary_codec() -> Codec:
     return _proto_binary_codec
 
 
-def proto_json_codec(registry: Registry | None = None) -> Codec:
+def proto_json_codec(
+    registry: Registry | None = None, *, ignore_unknown_fields: bool = True
+) -> Codec:
     """Return the Protocol Buffers JSON codec.
 
     Args:
         registry: An optional protobuf Registry to use for marshaling Any and extensions in messages.
                   If not provided, a default registry containing WKTs will be used.
+        ignore_unknown_fields: Whether to ignore unknown fields when decoding JSON messages. If not
+                  provided, defaults to True.
 
     """
-    if registry:
-        return ProtoJSONCodec(name=CODEC_NAME_JSON, registry=registry)
+    if registry or not ignore_unknown_fields:
+        return ProtoJSONCodec(
+            name=CODEC_NAME_JSON,
+            registry=registry,
+            ignore_unknown_fields=ignore_unknown_fields,
+        )
     return _proto_json_codec

--- a/src/connectrpc/compat/_codec.py
+++ b/src/connectrpc/compat/_codec.py
@@ -32,8 +32,11 @@ class ProtoBinaryCodec(Codec[Message, V]):
 class ProtoJSONCodec(Codec[Message, V]):
     """Codec for Protocol bytes | bytearrays JSON format."""
 
-    def __init__(self, name: str = "json") -> None:
+    def __init__(
+        self, name: str = "json", *, ignore_unknown_fields: bool = True
+    ) -> None:
         self._name = name
+        self._ignore_unknown_fields = ignore_unknown_fields
 
     def name(self) -> str:
         return self._name
@@ -43,7 +46,11 @@ class ProtoJSONCodec(Codec[Message, V]):
 
     def decode(self, data: bytes | bytearray, message_class: type[V]) -> V:
         message = message_class()
-        MessageFromJson(data, message)  # ty:ignore[invalid-argument-type] type is incorrect
+        MessageFromJson(
+            data,  # ty:ignore[invalid-argument-type] type is incorrect
+            message,
+            ignore_unknown_fields=self._ignore_unknown_fields,
+        )
         return message
 
 
@@ -62,6 +69,12 @@ def google_protobuf_binary_codec() -> Codec:
     return _proto_binary_codec
 
 
-def google_protobuf_json_codec() -> Codec:
-    """Return the Protocol Buffers JSON codec using google.protobuf."""
-    return _proto_json_codec
+def google_protobuf_json_codec(*, ignore_unknown_fields: bool = True) -> Codec:
+    """Return the Protocol Buffers JSON codec using google.protobuf.
+
+    Args:
+        ignore_unknown_fields: Whether to ignore unknown fields when decoding JSON messages. If not
+                  provided, defaults to True.
+
+    """
+    return ProtoJSONCodec(ignore_unknown_fields=ignore_unknown_fields)

--- a/test/test_roundtrip.py
+++ b/test/test_roundtrip.py
@@ -9,7 +9,7 @@ from pyqwest import Client, SyncClient
 from pyqwest.testing import ASGITransport, WSGITransport
 
 from connectrpc.code import Code
-from connectrpc.codec import proto_json_codec
+from connectrpc.codec import proto_binary_codec, proto_json_codec
 from connectrpc.errors import ConnectError
 
 from ._util import resolve_compression
@@ -73,6 +73,141 @@ async def test_roundtrip_async(proto_json: bool, compression_name: str) -> None:
         response = await client.make_hat(request=Size(inches=10))
     assert response.size == 10
     assert response.color == "green"
+
+
+# A request and a response containing a field the receiver's schema doesn't have,
+# as would happen when the peer is built against a newer version of the schema.
+_UNKNOWN_FIELD_REQUEST = b'{"inches": 10, "notAField": true}'
+_UNKNOWN_FIELD_RESPONSE = b'{"size": 10, "color": "green", "notAField": true}'
+
+
+@pytest.mark.parametrize("ignore_unknown_fields", [True, False])
+def test_roundtrip_sync_unknown_request_field(ignore_unknown_fields: bool) -> None:
+    requests: list[Size] = []
+
+    class RoundtripHaberdasherSync(HaberdasherSync):
+        def make_hat(self, request, _ctx):
+            requests.append(request)
+            return Hat(size=request.inches, color="green")
+
+    app = HaberdasherWSGIApplication(
+        RoundtripHaberdasherSync(),
+        codecs=[
+            proto_binary_codec(),
+            proto_json_codec(ignore_unknown_fields=ignore_unknown_fields),
+        ],
+    )
+    response = SyncClient(transport=WSGITransport(app=app)).post(
+        "http://localhost/connectrpc.example.Haberdasher/MakeHat",
+        content=_UNKNOWN_FIELD_REQUEST,
+        headers={"content-type": "application/json"},
+    )
+    if ignore_unknown_fields:
+        assert response.status == 200
+        assert response.json() == {"size": 10, "color": "green"}
+        assert requests == [Size(inches=10)]
+    else:
+        # The WSGI and ASGI servers report a decode failure with different
+        # codes, so only assert that the request was rejected.
+        assert response.status >= 400
+        error = response.json()
+        assert isinstance(error, dict)
+        assert "notAField" in error["message"]
+        assert requests == []
+
+
+@pytest.mark.parametrize("ignore_unknown_fields", [True, False])
+@pytest.mark.asyncio
+async def test_roundtrip_async_unknown_request_field(
+    ignore_unknown_fields: bool,
+) -> None:
+    requests: list[Size] = []
+
+    class RoundtripHaberdasher(Haberdasher):
+        async def make_hat(self, request, _ctx):
+            requests.append(request)
+            return Hat(size=request.inches, color="green")
+
+    app = HaberdasherASGIApplication(
+        RoundtripHaberdasher(),
+        codecs=[
+            proto_binary_codec(),
+            proto_json_codec(ignore_unknown_fields=ignore_unknown_fields),
+        ],
+    )
+    response = await Client(ASGITransport(app)).post(
+        "http://localhost/connectrpc.example.Haberdasher/MakeHat",
+        content=_UNKNOWN_FIELD_REQUEST,
+        headers={"content-type": "application/json"},
+    )
+    if ignore_unknown_fields:
+        assert response.status == 200
+        assert response.json() == {"size": 10, "color": "green"}
+        assert requests == [Size(inches=10)]
+    else:
+        assert response.status >= 400
+        error = response.json()
+        assert isinstance(error, dict)
+        assert "notAField" in error["message"]
+        assert requests == []
+
+
+@pytest.mark.parametrize("ignore_unknown_fields", [True, False])
+def test_roundtrip_sync_unknown_response_field(ignore_unknown_fields: bool) -> None:
+    def app(_environ, start_response):
+        start_response(
+            "200 OK",
+            [
+                ("content-type", "application/json"),
+                ("content-length", str(len(_UNKNOWN_FIELD_RESPONSE))),
+            ],
+        )
+        return [_UNKNOWN_FIELD_RESPONSE]
+
+    with HaberdasherClientSync(
+        "http://localhost",
+        http_client=SyncClient(WSGITransport(app=app)),
+        codec=proto_json_codec(ignore_unknown_fields=ignore_unknown_fields),
+    ) as client:
+        if ignore_unknown_fields:
+            assert client.make_hat(request=Size(inches=10)) == Hat(
+                size=10, color="green"
+            )
+        else:
+            with pytest.raises(ConnectError, match="notAField"):
+                client.make_hat(request=Size(inches=10))
+
+
+@pytest.mark.parametrize("ignore_unknown_fields", [True, False])
+@pytest.mark.asyncio
+async def test_roundtrip_async_unknown_response_field(
+    ignore_unknown_fields: bool,
+) -> None:
+    async def app(_scope, _receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(_UNKNOWN_FIELD_RESPONSE)).encode()),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": _UNKNOWN_FIELD_RESPONSE})
+
+    async with HaberdasherClient(
+        "http://localhost",
+        http_client=Client(ASGITransport(app)),
+        codec=proto_json_codec(ignore_unknown_fields=ignore_unknown_fields),
+    ) as client:
+        if ignore_unknown_fields:
+            assert await client.make_hat(request=Size(inches=10)) == Hat(
+                size=10, color="green"
+            )
+        else:
+            with pytest.raises(ConnectError, match="notAField"):
+                await client.make_hat(request=Size(inches=10))
 
 
 def test_roundtrip_sync_connect_get_empty_request() -> None:

--- a/test/test_roundtrip_google_compat.py
+++ b/test/test_roundtrip_google_compat.py
@@ -5,6 +5,7 @@ from pyqwest import Client, SyncClient
 from pyqwest.testing import ASGITransport, WSGITransport
 
 from connectrpc.compat import google_protobuf_binary_codec, google_protobuf_json_codec
+from connectrpc.errors import ConnectError
 
 from .google_compat.connectrpc.example.haberdasher_connect import (
     Haberdasher,
@@ -55,3 +56,138 @@ async def test_roundtrip_async(proto_json: bool) -> None:
         response = await client.make_hat(request=Size(inches=10))
     assert response.size == 10
     assert response.color == "green"
+
+
+# A request and a response containing a field the receiver's schema doesn't have,
+# as would happen when the peer is built against a newer version of the schema.
+_UNKNOWN_FIELD_REQUEST = b'{"inches": 10, "notAField": true}'
+_UNKNOWN_FIELD_RESPONSE = b'{"size": 10, "color": "green", "notAField": true}'
+
+
+@pytest.mark.parametrize("ignore_unknown_fields", [True, False])
+def test_roundtrip_sync_unknown_request_field(ignore_unknown_fields: bool) -> None:
+    requests: list[Size] = []
+
+    class RoundtripHaberdasherSync(HaberdasherSync):
+        def make_hat(self, request, _ctx):
+            requests.append(request)
+            return Hat(size=request.inches, color="green")
+
+    app = HaberdasherWSGIApplication(
+        RoundtripHaberdasherSync(),
+        codecs=[
+            google_protobuf_binary_codec(),
+            google_protobuf_json_codec(ignore_unknown_fields=ignore_unknown_fields),
+        ],
+    )
+    response = SyncClient(transport=WSGITransport(app=app)).post(
+        "http://localhost/connectrpc.example.Haberdasher/MakeHat",
+        content=_UNKNOWN_FIELD_REQUEST,
+        headers={"content-type": "application/json"},
+    )
+    if ignore_unknown_fields:
+        assert response.status == 200
+        assert response.json() == {"size": 10, "color": "green"}
+        assert requests == [Size(inches=10)]
+    else:
+        # The WSGI and ASGI servers report a decode failure with different
+        # codes, so only assert that the request was rejected.
+        assert response.status >= 400
+        error = response.json()
+        assert isinstance(error, dict)
+        assert "notAField" in error["message"]
+        assert requests == []
+
+
+@pytest.mark.parametrize("ignore_unknown_fields", [True, False])
+@pytest.mark.asyncio
+async def test_roundtrip_async_unknown_request_field(
+    ignore_unknown_fields: bool,
+) -> None:
+    requests: list[Size] = []
+
+    class RoundtripHaberdasher(Haberdasher):
+        async def make_hat(self, request, _ctx):
+            requests.append(request)
+            return Hat(size=request.inches, color="green")
+
+    app = HaberdasherASGIApplication(
+        RoundtripHaberdasher(),
+        codecs=[
+            google_protobuf_binary_codec(),
+            google_protobuf_json_codec(ignore_unknown_fields=ignore_unknown_fields),
+        ],
+    )
+    response = await Client(ASGITransport(app)).post(
+        "http://localhost/connectrpc.example.Haberdasher/MakeHat",
+        content=_UNKNOWN_FIELD_REQUEST,
+        headers={"content-type": "application/json"},
+    )
+    if ignore_unknown_fields:
+        assert response.status == 200
+        assert response.json() == {"size": 10, "color": "green"}
+        assert requests == [Size(inches=10)]
+    else:
+        assert response.status >= 400
+        error = response.json()
+        assert isinstance(error, dict)
+        assert "notAField" in error["message"]
+        assert requests == []
+
+
+@pytest.mark.parametrize("ignore_unknown_fields", [True, False])
+def test_roundtrip_sync_unknown_response_field(ignore_unknown_fields: bool) -> None:
+    def app(_environ, start_response):
+        start_response(
+            "200 OK",
+            [
+                ("content-type", "application/json"),
+                ("content-length", str(len(_UNKNOWN_FIELD_RESPONSE))),
+            ],
+        )
+        return [_UNKNOWN_FIELD_RESPONSE]
+
+    with HaberdasherClientSync(
+        "http://localhost",
+        http_client=SyncClient(WSGITransport(app=app)),
+        codec=google_protobuf_json_codec(ignore_unknown_fields=ignore_unknown_fields),
+    ) as client:
+        if ignore_unknown_fields:
+            assert client.make_hat(request=Size(inches=10)) == Hat(
+                size=10, color="green"
+            )
+        else:
+            with pytest.raises(ConnectError, match="notAField"):
+                client.make_hat(request=Size(inches=10))
+
+
+@pytest.mark.parametrize("ignore_unknown_fields", [True, False])
+@pytest.mark.asyncio
+async def test_roundtrip_async_unknown_response_field(
+    ignore_unknown_fields: bool,
+) -> None:
+    async def app(_scope, _receive, send):
+        await send(
+            {
+                "type": "http.response.start",
+                "status": 200,
+                "headers": [
+                    (b"content-type", b"application/json"),
+                    (b"content-length", str(len(_UNKNOWN_FIELD_RESPONSE)).encode()),
+                ],
+            }
+        )
+        await send({"type": "http.response.body", "body": _UNKNOWN_FIELD_RESPONSE})
+
+    async with HaberdasherClient(
+        "http://localhost",
+        http_client=Client(ASGITransport(app)),
+        codec=google_protobuf_json_codec(ignore_unknown_fields=ignore_unknown_fields),
+    ) as client:
+        if ignore_unknown_fields:
+            assert await client.make_hat(request=Size(inches=10)) == Hat(
+                size=10, color="green"
+            )
+        else:
+            with pytest.raises(ConnectError, match="notAField"):
+                await client.make_hat(request=Size(inches=10))


### PR DESCRIPTION
Other connect implementations do this and I think this just slipped past the cracks here